### PR TITLE
Add ECFs, EFPs and Razor variables

### DIFF
--- a/branchesProducer/BranchesProducer.py
+++ b/branchesProducer/BranchesProducer.py
@@ -4,38 +4,20 @@ import numpy as np
 import sys
 
 sys.path.append("../utilities/")
+import nameUtilities as nameutl
 import coffeaUtilities as cfutl
 import awkwardArrayUtilities as akutl
 import PtEtaPhiMLorentzVectorUtilities as vecutl
 import physicsUtilities as phutl
 import variablesComputation.awkwardArray.jetVariables as jetvars
+import variablesComputation.awkwardArray.eventVariables as evtvars
 
 
-## Define some helper functions - Could be put in separate file later
-
-def jet_algo_2_jet_collection(jet_algo):
-    """Helper function converting jet algorithm name into jet collection name.
-
-    Args:
-        jet_algo (str)
-
-    Returns:
-        str
-    """
-
-    table = {
-        "ak4": "Jet",
-        "ak8": "FatJet",
-    }
-
-    return table[jet_algo.lower()]
-
-
-def get_jets(events, jet_type):
-    """Get jet collection for a given jet type.
+def get_met(events, met_collection_name="MET"):
+    """Get met collection.
 
     Args:
-        events (ak.Array): the Events TTree opened with uproot.
+        events (awkward.Array): the Events TTree opened with uproot.
         jet_type (str): AK4 or AK8
 
     Returns:
@@ -43,7 +25,34 @@ def get_jets(events, jet_type):
             that can be used as a coffea PtEtaPhiMLorentzVector.
     """
 
-    jet_collection = jet_algo_2_jet_collection(jet_type)
+    met_branch = eval("events." + met_collection_name)
+
+    met = ak.zip(
+        {
+            "pt"    : met_branch.pt,
+            "mass"  : ak.zeros_like(met_branch.pt),
+            "eta"   : ak.zeros_like(met_branch.pt),
+            "phi"   : met_branch.phi,
+        },
+        with_name="PtEtaPhiMLorentzVector",
+    )
+
+    return met
+
+
+def get_jets(events, jet_type):
+    """Get jet collection for a given jet type.
+
+    Args:
+        events (awkward.Array): the Events TTree opened with uproot.
+        jet_type (str): AK4 or AK8
+
+    Returns:
+        awkward.Array: ak array with field pt, eta, phi, mass,
+            that can be used as a coffea PtEtaPhiMLorentzVector.
+    """
+
+    jet_collection = nameutl.jet_algo_2_jet_collection(jet_type)
     jet_branch = eval("events." + jet_collection)
 
     jets = ak.zip(
@@ -56,6 +65,8 @@ def get_jets(events, jet_type):
         with_name="PtEtaPhiMLorentzVector",
     )
 
+    jets = ak.with_field(jets, vecutl.momentum(jets), where="momentum")
+
     return jets
 
 
@@ -63,7 +74,7 @@ def get_pf_cands(events, jet_type):
     """Get jet pf candidates collection for a given jet type.
 
     Args:
-        events (ak.Array): the Events TTree opened with uproot.
+        events (awkward.Array): the Events TTree opened with uproot.
         jet_type (str): AK4 or AK8
 
     Returns:
@@ -109,6 +120,8 @@ def get_pf_cands(events, jet_type):
     #    with_name="PtEtaPhiMLorentzVector",
     #)
 
+    pf_cands = ak.with_field(pf_cands, vecutl.rapidity(pf_cands), where="rapidity")
+
     return pf_cands
 
 
@@ -141,25 +154,9 @@ class BranchesProducer(processor.ProcessorABC):
 
         self.jet_types = ["AK4", "AK8"]  # capitals used because capitals are used in PFNanoAOD
 
-        
-        branches = {}
-
-        branches["genWeight"]: cfutl.column_accumulator(np.float64)
-
-        for jet_type in self.jet_types:
-            jet_collection = jet_algo_2_jet_collection(jet_type)
-            branches["n" + jet_collection]: cfutl.column_accumulator(np.int64)
-            branches[jet_collection + "_ptD"]: cfutl.column_accumulator(np.float64)
-            branches[jet_collection + "_girth"]: cfutl.column_accumulator(np.float64)
-            branches[jet_collection + "_axisMajor"]: cfutl.column_accumulator(np.float64)
-            branches[jet_collection + "_axisMinor"]: cfutl.column_accumulator(np.float64)
-            branches[jet_collection + "_axisAvg"]: cfutl.column_accumulator(np.float64)
-            if jet_type == "AK8":
-                branches[jet_collection + "_chHEF"]: cfutl.column_accumulator(np.float64)
-                branches[jet_collection + "_neHEF"]: cfutl.column_accumulator(np.float64)
- 
         ## Define accumulator
-        self._accumulator = processor.dict_accumulator(branches)
+        #  By using dict_accumulator, the branches type do not have to be defined
+        self._accumulator = processor.dict_accumulator({})
 
 
     @property
@@ -171,10 +168,10 @@ class BranchesProducer(processor.ProcessorABC):
         """Compute new quantities to be added to the ROOT NTuple.
 
         Args:
-            events (ak.Array): the Events TTree opened with uproot.
+            events (awkward.Array): the Events TTree opened with uproot.
 
         Returns:
-            dict[str, coffea.processor.dict_accumulator]
+            coffea.processor.dict_accumulator
         """
 
         ## Define accumulator
@@ -182,25 +179,62 @@ class BranchesProducer(processor.ProcessorABC):
 
         output["genWeight"] = cfutl.accumulate(events.genWeight)
 
+        met = get_met(events, "MET")
+
         for jet_type in self.jet_types:
 
-            jet_collection = jet_algo_2_jet_collection(jet_type)
+            jet_collection = nameutl.jet_algo_2_jet_collection(jet_type)
 
             jets = get_jets(events, jet_type)
             jet_pf_cands = get_pf_cands(events, jet_type)
             njets = get_collection_size(events, jet_collection)
+            sum_pfcands_pt = jetvars.calculate_sum_pfcands_pt(jet_pf_cands, jagged=False)
 
             output["n" + jet_collection] = cfutl.accumulate(njets)
-            output[jet_collection + "_ptD"] = cfutl.accumulate(jetvars.calculate_ptD(jet_pf_cands)[0])
-            output[jet_collection + "_girth"] = cfutl.accumulate(jetvars.calculate_girth(jet_pf_cands, jets, njets)[0])
-            axis_major, axis_minor, axis_avg = jetvars.calculate_axes(jet_pf_cands, jets, njets)
+            output[jet_collection + "_ptD"] = cfutl.accumulate(jetvars.calculate_ptD(jet_pf_cands))
+            output[jet_collection + "_girth"] = cfutl.accumulate(jetvars.calculate_girth(jet_pf_cands, jets, njets=njets))
+            axis_major, axis_minor, axis_avg = jetvars.calculate_axes(jet_pf_cands, jets, njets=njets)
             output[jet_collection + "_axisMajor"] = cfutl.accumulate(axis_major)
             output[jet_collection + "_axisMinor"] = cfutl.accumulate(axis_minor)
             output[jet_collection + "_axisAvg"] = cfutl.accumulate(axis_avg)
 
+            mr = evtvars.calculate_razor_MR(jets, njets=njets)
+            mrt = evtvars.calculate_razor_MRT(jets, met, njets=njets)
+            output["RazorMR_" + jet_collection] = cfutl.accumulate(mr)
+            output["RazorMRT_" + jet_collection] = cfutl.accumulate(mrt)
+            output["RazorR_" + jet_collection] = cfutl.accumulate(evtvars.calculate_razor_R(mr, mrt))
+
             if jet_type == "AK8":
-                output[jet_collection + "_chHEF"] = cfutl.accumulate(jetvars.calculate_chHEF(jet_pf_cands, jets, njets)[0])
-                output[jet_collection + "_neHEF"] = cfutl.accumulate(jetvars.calculate_neHEF(jet_pf_cands, jets, njets)[0])
+
+                output[jet_collection + "_chHEF"] = cfutl.accumulate(jetvars.calculate_chHEF(jet_pf_cands, jets, njets=njets))
+                output[jet_collection + "_neHEF"] = cfutl.accumulate(jetvars.calculate_neHEF(jet_pf_cands, jets, njets=njets))
+
+                beta = 1
+                e2b1 = jetvars.calculate_ecf_e2(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt)
+                e3b1 = jetvars.calculate_ecfs_e3(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=False)
+                v1e3b1, v2e3b1, e3b1 = jetvars.calculate_ecfs_e3(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=True)
+                e4b1 = jetvars.calculate_ecfs_e4(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=False)
+                v1e4b1, v2e4b1, v3e4b1, v4e4b1, v5e4b1, e4b1 = jetvars.calculate_ecfs_e4(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=True)
+                output[jet_collection + "_e2b1"] = cfutl.accumulate(e2b1)
+                output[jet_collection + "_v1e3b1"] = cfutl.accumulate(v1e3b1)
+                output[jet_collection + "_v2e3b1"] = cfutl.accumulate(v2e3b1)
+                output[jet_collection + "_e3b1"] = cfutl.accumulate(e3b1)
+                output[jet_collection + "_v1e4b1"] = cfutl.accumulate(v1e4b1)
+                output[jet_collection + "_v2e4b1"] = cfutl.accumulate(v2e4b1)
+                output[jet_collection + "_v3e4b1"] = cfutl.accumulate(v3e4b1)
+                output[jet_collection + "_v4e4b1"] = cfutl.accumulate(v4e4b1)
+                output[jet_collection + "_v5e4b1"] = cfutl.accumulate(v5e4b1)
+                output[jet_collection + "_e4b1"] = cfutl.accumulate(e4b1)
+                output[jet_collection + "_c2b1"] = cfutl.accumulate(jetvars.calculate_ecf_c(1., e2b1, e3b1))
+                output[jet_collection + "_d2b1"] = cfutl.accumulate(jetvars.calculate_ecf_d(1., e2b1, e3b1))
+                output[jet_collection + "_m2b1"] = cfutl.accumulate(jetvars.calculate_ecf_m(e2b1, v1e3b1))
+                output[jet_collection + "_n2b1"] = cfutl.accumulate(jetvars.calculate_ecf_n(e2b1, v2e3b1))
+
+                efp_degree = 6
+                efps = jetvars.calculate_efps(jet_pf_cands, efp_degree)
+                # Not storing EFP0, which is always 1, on purpose
+                for idx, efp in enumerate(efps[1:]):
+                    output[jet_collection + "_efp%dd%d" %(idx+1, efp_degree)] = cfutl.accumulate(efp)
 
         return output
 

--- a/branchesProducer/BranchesProducer.py
+++ b/branchesProducer/BranchesProducer.py
@@ -52,7 +52,7 @@ def get_jets(events, jet_type):
             that can be used as a coffea PtEtaPhiMLorentzVector.
     """
 
-    jet_collection = nameutl.jet_algo_2_jet_collection(jet_type)
+    jet_collection = nameutl.jet_algo_name_to_jet_collection_name(jet_type)
     jet_branch = eval("events." + jet_collection)
 
     jets = ak.zip(
@@ -183,7 +183,7 @@ class BranchesProducer(processor.ProcessorABC):
 
         for jet_type in self.jet_types:
 
-            jet_collection = nameutl.jet_algo_2_jet_collection(jet_type)
+            jet_collection = nameutl.jet_algo_name_to_jet_collection_name(jet_type)
 
             jets = get_jets(events, jet_type)
             jet_pf_cands = get_pf_cands(events, jet_type)
@@ -211,9 +211,9 @@ class BranchesProducer(processor.ProcessorABC):
 
                 beta = 1
                 e2b1 = jetvars.calculate_ecf_e2(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt)
-                e3b1 = jetvars.calculate_ecfs_e3(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=False)
+                #e3b1 = jetvars.calculate_ecfs_e3(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=False)
                 v1e3b1, v2e3b1, e3b1 = jetvars.calculate_ecfs_e3(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=True)
-                e4b1 = jetvars.calculate_ecfs_e4(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=False)
+                #e4b1 = jetvars.calculate_ecfs_e4(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=False)
                 v1e4b1, v2e4b1, v3e4b1, v4e4b1, v5e4b1, e4b1 = jetvars.calculate_ecfs_e4(jet_pf_cands, beta, sum_pfcands_pt=sum_pfcands_pt, calculate_ecfgs=True)
                 output[jet_collection + "_e2b1"] = cfutl.accumulate(e2b1)
                 output[jet_collection + "_v1e3b1"] = cfutl.accumulate(v1e3b1)

--- a/branchesProducer/produceBranches.py
+++ b/branchesProducer/produceBranches.py
@@ -9,6 +9,7 @@ import argparse
 from BranchesProducer import BranchesProducer
 
 
+# Note: This function could be put in a separate file to be used by other scripts as well
 def make_events_branches(accumulator, debug):
     """Make branches for Events tree."""
 
@@ -54,8 +55,16 @@ def make_events_branches(accumulator, debug):
     return branches, branches_init
 
 
-def write_root_file(accumulator, output_file, debug):
-    """
+def write_root_file(accumulator, output_file_name, debug):
+    """Write histograms, stored in a coffea accumulator, to a ROOT file.
+
+    Args:
+        accumulator (coffea.processor.dict_accumulator)
+        output_file_name (str): Name of the ROOT file to create
+        debug (bool)
+
+    Returns:
+        None
     """
 
     # Making branches to write to Events tree
@@ -69,10 +78,12 @@ def write_root_file(accumulator, output_file, debug):
 
     # Save branches to ROOT file
     # Need to use uproot3 because it is not implemented yet in uproot4 (Feb. 2021)
-    with uproot3.recreate(output_file) as f:
+    # Need to use compression=None because there is a bug with EFPs when the file is compressed:
+    # More info at https://github.com/scikit-hep/uproot3/issues/506
+    with uproot3.recreate(output_file_name, compression=None) as f:
         f["Events"] = uproot3.newtree(branches_init)
         f["Events"].extend(branches)
-        print("\nTTree Events saved to output file %s" %output_file)
+        print("\nTTree Events saved to output file %s" %output_file_name)
 
     return
 

--- a/utilities/PtEtaPhiMLorentzVectorUtilities.py
+++ b/utilities/PtEtaPhiMLorentzVectorUtilities.py
@@ -28,10 +28,7 @@ def rapidity(obj):
 
 
 def pz(obj, use_rapidity=False):
-    if use_rapidity:
-        obj_eta = obj.y
-    else:
-        obj_eta = obj.eta
+    obj_eta = obj.y if use_rapidity else obj.eta
     return np.sinh(obj_eta) * np.sqrt( obj.pt**2 + obj.mass**2 )
 
 

--- a/utilities/PtEtaPhiMLorentzVectorUtilities.py
+++ b/utilities/PtEtaPhiMLorentzVectorUtilities.py
@@ -23,8 +23,21 @@ def make_PtEtaPhiMLorentzVector(pt, eta, phi, mass):
     return vec
 
 
-def delta_r(obj1, obj2):
-    return obj1.delta_r(obj2)
+def rapidity(obj):
+    return np.arcsinh(np.sinh(obj.eta)/np.sqrt(1+obj.mass**2/obj.pt**2))
+
+
+def pz(obj, use_rapidity=False):
+    if use_rapidity:
+        obj_eta = obj.y
+    else:
+        obj_eta = obj.eta
+    return np.sinh(obj_eta) * np.sqrt( obj.pt**2 + obj.mass**2 )
+
+
+def momentum(obj):
+    return np.sqrt( obj.pt**2 + obj.pz**2 )
+
 
 def delta_phi(obj1, obj2):
     return obj1.delta_phi(obj2)
@@ -37,6 +50,28 @@ def delta_eta(obj1, obj2):
 
 def abs_delta_eta(obj1, obj2):
     return abs(delta_eta(obj1, obj2))
+
+def delta_rapidity(obj1, obj2):
+    return obj1.rapidity - obj2.rapidity
+
+def delta_r_rapidity(obj1, obj2):
+    
+    dy = delta_rapidity(obj1, obj2)
+    dphi = delta_phi(obj1, obj2)
+
+    return np.sqrt(dy**2 + dphi**2)
+
+def delta_r_pseudorapidity(obj1, obj2):
+    
+    return obj1.delta_r(obj2)
+
+
+def delta_r(obj1, obj2, use_rapidity=False):
+    if use_rapidity:
+        return delta_r_rapidity(obj1, obj2)
+    else:
+        return delta_r_pseudorapidity(obj1, obj2)
+
 
 def mass(obj1, obj2):
     return (obj1+obj2).mass

--- a/utilities/awkwardArrayUtilities.py
+++ b/utilities/awkwardArrayUtilities.py
@@ -110,5 +110,5 @@ def swap_axes(ak_array):
     return ak_array
 
 
-def ak_to_ptyphim(ak_array, jet_idx):
+def ak_to_ptyphim_four_vectors(ak_array, jet_idx):
     return np.array([ [ [c.pt, c.rapidity, c.phi, c.mass] for c in ak_array[ievent][ak_array[ievent].jetIdx == jet_idx] ] if ak.count(ak_array[ievent][ak_array[ievent].jetIdx == jet_idx], axis=None)>0 else [[1,1,1,1]] for ievent in range(ak.num(ak_array, axis=0)) ], dtype=object)

--- a/utilities/awkwardArrayUtilities.py
+++ b/utilities/awkwardArrayUtilities.py
@@ -1,4 +1,5 @@
 import awkward as ak
+import numpy as np
 
 
 def divide_ak_arrays(ak_array1, ak_array2, division_by_zero_value=1., verbose=False):
@@ -107,3 +108,7 @@ def swap_axes(ak_array):
     np_array = np_array.T
     ak_array = ak.Array([np_array])     # Can't avoid that copy in memory!!!
     return ak_array
+
+
+def ak_to_ptyphim(ak_array, jet_idx):
+    return np.array([ [ [c.pt, c.rapidity, c.phi, c.mass] for c in ak_array[ievent][ak_array[ievent].jetIdx == jet_idx] ] if ak.count(ak_array[ievent][ak_array[ievent].jetIdx == jet_idx], axis=None)>0 else [[1,1,1,1]] for ievent in range(ak.num(ak_array, axis=0)) ], dtype=object)

--- a/utilities/coffeaUtilities.py
+++ b/utilities/coffeaUtilities.py
@@ -30,10 +30,6 @@ def column_accumulator(type_):
     return processor.column_accumulator(np.array([], dtype=type_))
 
 
-def value_accumulator(type_, initial=0):
-    return processor.value_accumulator(type_, initial=initial)
-
-
 def accumulate(ak_array):
     """Accumulate ak array into a coffea processor column accumulator.
 

--- a/utilities/coffeaUtilities.py
+++ b/utilities/coffeaUtilities.py
@@ -30,6 +30,10 @@ def column_accumulator(type_):
     return processor.column_accumulator(np.array([], dtype=type_))
 
 
+def value_accumulator(type_, initial=0):
+    return processor.value_accumulator(type_, initial=initial)
+
+
 def accumulate(ak_array):
     """Accumulate ak array into a coffea processor column accumulator.
 

--- a/utilities/nameUtilities.py
+++ b/utilities/nameUtilities.py
@@ -1,4 +1,4 @@
-def jet_algo_2_jet_collection(jet_algo):
+def jet_algo_name_to_jet_collection_name(jet_algo):
     """Helper function converting jet algorithm name into jet collection name.
 
     Args:
@@ -16,7 +16,7 @@ def jet_algo_2_jet_collection(jet_algo):
     return table[jet_algo.lower()]
 
 
-def jet_collection_2_jet_algo(jet_collection):
+def jet_collection_name_to_jet_algo_name(jet_collection):
     """Helper function converting jet collection name into jet algorithm name.
 
     Args:

--- a/utilities/nameUtilities.py
+++ b/utilities/nameUtilities.py
@@ -1,0 +1,36 @@
+def jet_algo_2_jet_collection(jet_algo):
+    """Helper function converting jet algorithm name into jet collection name.
+
+    Args:
+        jet_algo (str)
+
+    Returns:
+        str
+    """
+
+    table = {
+        "ak4": "Jet",
+        "ak8": "FatJet",
+    }
+
+    return table[jet_algo.lower()]
+
+
+def jet_collection_2_jet_algo(jet_collection):
+    """Helper function converting jet collection name into jet algorithm name.
+
+    Args:
+        jet_collection (str)
+
+    Returns:
+        str
+    """
+
+    table = {
+        "jet": "ak4",
+        "fatjet": "ak8",
+    }
+
+    return table[jet_collection.lower()]
+
+

--- a/utilities/variablesComputation/awkwardArray/eventVariables.py
+++ b/utilities/variablesComputation/awkwardArray/eventVariables.py
@@ -1,0 +1,102 @@
+import awkward as ak
+import numpy as np
+import sys
+
+sys.path.append("../../../")
+import awkwardArrayUtilities as akutl
+
+
+def calculate_number_of_jets(jets):
+    """Calculate number of jets in all events.
+
+    Args:
+        jets (awkward.Array): Jagged ak array where axis 0 is the event axis
+            and axis 1 is the jet axis.
+
+    Returns:
+        awkward.Array
+    """
+
+    return ak.num(jets, axis=1)
+
+
+def calculate_razor_MR(jets, njets=None, nan_value=0):
+    """Calculate M_R Razor variable for all events using 2 leading jets.
+
+    If an event has less than 2 jets, returns -1 for that event.
+
+    Args:
+        jets (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the jet axis
+            with fields pt, rapidity, phi and mass and with name
+            PtEtaPhiMLorentzVector.
+        njets (awkward.Array, optional, default=None):
+            Ak array with one axis with number of jets in each event.
+            If None, will be computed from jets.
+        nan_value (float, optional, default=0):
+            Value to use when the event has less than jet_idx+1 jet(s).
+
+    Returns:
+        awkward.Array
+    """
+
+    if njets is None:
+        njets = calculate_number_of_jets(jets)
+
+    masked_jets = ak.mask(jets, njets>=2)
+    jets0 = masked_jets[:, 0]
+    jets1 = masked_jets[:, 1]
+    mr = np.sqrt( (jets0.momentum + jets1.momentum) ** 2 - (jets0.pz + jets1.pz) ** 2 )
+    mr = ak.fill_none(mr, nan_value)
+
+    return mr
+
+
+def calculate_razor_MRT(jets, met, njets=None, nan_value=0):
+    """Calculate M^R_T Razor variable for all events using 2 leading jets.
+
+    If an event has less than 2 jets, returns -1 for that event.
+
+    Args:
+        jets (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the jet axis
+            with fields pt, eta, phi and mass and with name
+            PtEtaPhiMLorentzVector.
+        met (awkward.Array):
+            Missing transverse energy. 1D ak array with fields pt, eta, phi,
+            mass and with name PtEtaPhiMLorentzVector.
+        njets (awkward.Array, optional, default=None):
+            Ak array with one axis with number of jets in each event.
+            If None, will be computed from jets.
+        nan_value (float, optional, default=0):
+            Value to use when the event has less than jet_idx+1 jet(s).
+
+    Returns:
+        awkward.Array
+    """
+
+    if njets is None:
+        njets = calculate_number_of_jets(jets)
+
+    masked_jets = ak.mask(jets, njets>=2)
+    masked_met = ak.mask(met, njets>=2)
+    jets0 = masked_jets[:, 0]
+    jets1 = masked_jets[:, 1]
+    mrt = np.sqrt( met.pt * (jets0.pt + jets1.pt) - met.dot(jets0 + jets1) ) / np.sqrt(2)
+    mrt = ak.fill_none(mrt, nan_value)
+
+    return mrt
+
+
+def calculate_razor_R(mr, mrt):
+    """Calculate R Razor variable for all events from M_R and M^R_T variables.
+
+    Args:
+        mr (awkward.Array)
+        mrt (awkward.Array)
+    
+    Returns:
+        awkward.Array
+    """
+
+    return akutl.divide_ak_arrays(mrt, mr, division_by_zero_value=0.)

--- a/utilities/variablesComputation/awkwardArray/eventVariables.py
+++ b/utilities/variablesComputation/awkwardArray/eventVariables.py
@@ -23,8 +23,6 @@ def calculate_number_of_jets(jets):
 def calculate_razor_MR(jets, njets=None, nan_value=0):
     """Calculate M_R Razor variable for all events using 2 leading jets.
 
-    If an event has less than 2 jets, returns nan_value for that event.
-
     Args:
         jets (awkward.Array):
             Ak array where axis 0 is the event axis, axis 1 is the jet axis
@@ -34,7 +32,7 @@ def calculate_razor_MR(jets, njets=None, nan_value=0):
             Ak array with one axis with number of jets in each event.
             If None, will be computed from jets.
         nan_value (float, optional, default=0):
-            Value to use when the event has less than jet_idx+1 jet(s).
+            Value to use when the event has less than 2 jets.
 
     Returns:
         awkward.Array
@@ -55,8 +53,6 @@ def calculate_razor_MR(jets, njets=None, nan_value=0):
 def calculate_razor_MRT(jets, met, njets=None, nan_value=0):
     """Calculate M^R_T Razor variable for all events using 2 leading jets.
 
-    If an event has less than 2 jets, returns nan_value for that event.
-
     Args:
         jets (awkward.Array):
             Ak array where axis 0 is the event axis, axis 1 is the jet axis
@@ -69,7 +65,7 @@ def calculate_razor_MRT(jets, met, njets=None, nan_value=0):
             Ak array with one axis with number of jets in each event.
             If None, will be computed from jets.
         nan_value (float, optional, default=0):
-            Value to use when the event has less than jet_idx+1 jet(s).
+            Value to use when the event has less than 2 jets.
 
     Returns:
         awkward.Array

--- a/utilities/variablesComputation/awkwardArray/eventVariables.py
+++ b/utilities/variablesComputation/awkwardArray/eventVariables.py
@@ -23,7 +23,7 @@ def calculate_number_of_jets(jets):
 def calculate_razor_MR(jets, njets=None, nan_value=0):
     """Calculate M_R Razor variable for all events using 2 leading jets.
 
-    If an event has less than 2 jets, returns -1 for that event.
+    If an event has less than 2 jets, returns nan_value for that event.
 
     Args:
         jets (awkward.Array):
@@ -55,7 +55,7 @@ def calculate_razor_MR(jets, njets=None, nan_value=0):
 def calculate_razor_MRT(jets, met, njets=None, nan_value=0):
     """Calculate M^R_T Razor variable for all events using 2 leading jets.
 
-    If an event has less than 2 jets, returns -1 for that event.
+    If an event has less than 2 jets, returns nan_value for that event.
 
     Args:
         jets (awkward.Array):
@@ -88,7 +88,7 @@ def calculate_razor_MRT(jets, met, njets=None, nan_value=0):
     return mrt
 
 
-def calculate_razor_R(mr, mrt):
+def calculate_razor_R(mr, mrt, nan_value=0):
     """Calculate R Razor variable for all events from M_R and M^R_T variables.
 
     Args:
@@ -99,4 +99,4 @@ def calculate_razor_R(mr, mrt):
         awkward.Array
     """
 
-    return akutl.divide_ak_arrays(mrt, mr, division_by_zero_value=0.)
+    return akutl.divide_ak_arrays(mrt, mr, division_by_zero_value=nan_value)

--- a/utilities/variablesComputation/awkwardArray/jetVariables.py
+++ b/utilities/variablesComputation/awkwardArray/jetVariables.py
@@ -213,7 +213,7 @@ def calculate_efps_1_jet(jet_idx, pf_cands, degree):
         numpy.ndarray
     """
 
-    jet_pf_cands_ptyphim = akutl.ak_to_ptyphim(pf_cands, jet_idx)
+    jet_pf_cands_ptyphim = akutl.ak_to_ptyphim_four_vectors(pf_cands, jet_idx)
     
     efpset = ef.EFPSet('d<='+str(degree), measure='hadr', beta=1, normed=True, verbose=False, coords="ptyphim")
     efps = efpset.batch_compute(jet_pf_cands_ptyphim)

--- a/utilities/variablesComputation/awkwardArray/jetVariables.py
+++ b/utilities/variablesComputation/awkwardArray/jetVariables.py
@@ -1,3 +1,4 @@
+import energyflow as ef
 import awkward as ak
 import numpy as np
 import sys
@@ -24,6 +25,28 @@ def get_max_jet_idx(pf_cands):
     return ak.max(pf_cands.jetIdx)
 
 
+def calculate_sum_pfcands_pt_1_jet(jet_idx, pf_cands):
+    """Returns the sum of PF candidates pT for for all jets of a given index for all events.
+
+    Returns 0 for events having no jet with jet index jet_idx.
+
+    Args:
+        jet_idx (int)
+        pf_cands (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the PF
+            candidates axis with fields pt and jetIdx.
+        nan_value (float, optional, default=-1):
+            Value to use when the event has less than jet_idx+1 jet(s).
+        
+    Returns:
+        awkward.Array
+    """
+
+    jet_pf_cands = pf_cands[(pf_cands.jetIdx == jet_idx)]
+
+    return ak.sum(jet_pf_cands.pt, axis=1)
+
+
 def calculate_ptD_1_jet(jet_idx, pf_cands, nan_value=-1):
     """Calculate ptD for all jets of a given index for all events.
 
@@ -36,17 +59,17 @@ def calculate_ptD_1_jet(jet_idx, pf_cands, nan_value=-1):
             Value to use when the event has less than jet_idx+1 jet(s).
 
     Returns:
-        [awkward.Array]
+        awkward.Array
 
     Examples:
-	>>> pf_cands_idx = ak.Array([[0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2]])
-	>>> pf_cands_pt = ak.Array([[280, 150, 150, 130, 70], [500, 300, 400, 300, 150, 100]])
-	>>> pf_cands = ak.zip({"jetIdx": pf_cands_idx, "pt": pf_cands_pt})
-	>>> jet_idx = 2
-	>>> calculate_ptD_1_jet(jet_idx, pf_cands)
+        >>> pf_cands_idx = ak.Array([[0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2]])
+        >>> pf_cands_pt = ak.Array([[280, 150, 150, 130, 70], [500, 300, 400, 300, 150, 100]])
+        >>> pf_cands = ak.zip({"jetIdx": pf_cands_idx, "pt": pf_cands_pt})
+        >>> jet_idx = 2
+        >>> calculate_ptD_1_jet(jet_idx, pf_cands)
         [<Array [0.601, 0.714] type='2 * float64'>]
-	>>> jet_idx = 2
-	>>> calculate_ptD_1_jet(jet_idx, pf_cands)
+        >>> jet_idx = 2
+        >>> calculate_ptD_1_jet(jet_idx, pf_cands)
         [<Array [-1, 0.721] type='2 * float64'>]
     """
 
@@ -56,7 +79,7 @@ def calculate_ptD_1_jet(jet_idx, pf_cands, nan_value=-1):
     denominator = ak.sum(pf_cands_pt, axis=1)
     ptD = akutl.divide_ak_arrays(numerator, denominator, division_by_zero_value=nan_value)
 
-    return [ptD]
+    return ptD
 
 
 def calculate_girth_1_jet(jet_idx, pf_cands, jets, njets, nan_value=-1):
@@ -78,23 +101,23 @@ def calculate_girth_1_jet(jet_idx, pf_cands, jets, njets, nan_value=-1):
             Value to use when the event has less than jet_idx+1 jet(s).
 
     Returns:
-        [awkward.Array]
+        awkward.Array
 
     Examples:
-	>>> pf_cands_idx = ak.Array([[0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2]])
-	>>> pf_cands_pt = ak.Array([[280, 150, 150, 130, 70], [500, 300, 400, 300, 150, 100]])
-	>>> pf_cands_eta = ak.Array([[0.8, 0.87, -0.3, -0.2, -0.25], [0.5, 0.45, -1.4, -1.5, 0.1, 0.2]])
-	>>> pf_cands_phi = ak.Array([[0.2, 0.28, 3.1, -3.1, 2.8], [-1.5, -1.2, 2.0, 2.5, -2.6, -2.9]])
-	>>> pf_cands_mass = ak.Array([[50, 40, 20, 25, 23], [100, 50, 20, 45, 30, 15]])
-	>>> pf_cands = ak.zip({"jetIdx": pf_cands_idx, "pt": pf_cands_pt, "eta": pf_cands_eta, "phi": pf_cands_phi, "mass": pf_cands_mass})
-	>>> jets_pt = ak.Array([[430, 350], [800, 700, 250]])
-	>>> jets_eta = ak.Array([[0.8, -0.28], [0.48, -1.45, 0.15]])
-	>>> jets_phi = ak.Array([[0.25, 3.0], [-1.4, 2.2, -2.55]])
-	>>> jets_mass = ak.Array([[20, 40], [15, 80, 50]])
-	>>> jets = ak.zip({"pt": jets_pt, "eta": jets_eta, "phi": jets_phi, "mass": jets_mass})
-	>>> njets = ak.Array([2, 3])
-	>>> jet_idx = 1
-	>>> calculate_girth_1_jet(jet_idx, pf_cands, jets, njets)
+        >>> pf_cands_idx = ak.Array([[0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2]])
+        >>> pf_cands_pt = ak.Array([[280, 150, 150, 130, 70], [500, 300, 400, 300, 150, 100]])
+        >>> pf_cands_eta = ak.Array([[0.8, 0.87, -0.3, -0.2, -0.25], [0.5, 0.45, -1.4, -1.5, 0.1, 0.2]])
+        >>> pf_cands_phi = ak.Array([[0.2, 0.28, 3.1, -3.1, 2.8], [-1.5, -1.2, 2.0, 2.5, -2.6, -2.9]])
+        >>> pf_cands_mass = ak.Array([[50, 40, 20, 25, 23], [100, 50, 20, 45, 30, 15]])
+        >>> pf_cands = ak.zip({"jetIdx": pf_cands_idx, "pt": pf_cands_pt, "eta": pf_cands_eta, "phi": pf_cands_phi, "mass": pf_cands_mass})
+        >>> jets_pt = ak.Array([[430, 350], [800, 700, 250]])
+        >>> jets_eta = ak.Array([[0.8, -0.28], [0.48, -1.45, 0.15]])
+        >>> jets_phi = ak.Array([[0.25, 3.0], [-1.4, 2.2, -2.55]])
+        >>> jets_mass = ak.Array([[20, 40], [15, 80, 50]])
+        >>> jets = ak.zip({"pt": jets_pt, "eta": jets_eta, "phi": jets_phi, "mass": jets_mass})
+        >>> njets = ak.Array([2, 3])
+        >>> jet_idx = 1
+        >>> calculate_girth_1_jet(jet_idx, pf_cands, jets, njets)
         [<Array [0.158, 0.248] type='2 * float64'>]
     """
 
@@ -111,7 +134,7 @@ def calculate_girth_1_jet(jet_idx, pf_cands, jets, njets, nan_value=-1):
     girth = akutl.divide_ak_arrays(numerator, denominator, division_by_zero_value=nan_value)
     girth = ak.fill_none(girth, nan_value)
 
-    return [girth]
+    return girth
 
 
 def calculate_axes_1_jet(jet_idx, pf_cands, jets, njets, nan_value=-1):
@@ -133,7 +156,7 @@ def calculate_axes_1_jet(jet_idx, pf_cands, jets, njets, nan_value=-1):
             Value to use when the event has less than jet_idx+1 jet(s).
 
     Returns:
-        [awkward.Array, awkward.Array, awkward.Array]
+        tuple: (awkward.Array, awkward.Array, awkward.Array)
     """
 
     jet_pf_cands = pf_cands[(pf_cands.jetIdx == jet_idx)]
@@ -168,7 +191,200 @@ def calculate_axes_1_jet(jet_idx, pf_cands, jets, njets, nan_value=-1):
     axis_minor = ak.fill_none(ak.nan_to_num(axis_minor, nan=nan_value), nan_value)
     axis_avg   = ak.fill_none(ak.nan_to_num(axis_avg  , nan=nan_value), nan_value)
     
-    return [axis_major, axis_minor, axis_avg]
+    return axis_major, axis_minor, axis_avg
+
+
+def calculate_efps_1_jet(jet_idx, pf_cands, degree):
+    """Calculate EFPs for all jets of a given index for all events.
+
+    Calculates Energy Flow Polynomials for graphs with degree (= number of
+    edges) at least "degree" for all jets of a given index for all events.
+    For jets with less constituents than required, the corresponding EFP is
+    0. This is used to return 0 for events without jet with index "jet_idx".
+
+    Args:
+        jet_idx (int)
+        pf_cands (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the PF
+            candidates axis with fields pt, rapidity, phi, mass and jetIdx,
+            and with name PtEtaPhiMLorentzVector.
+
+    Returns:
+        numpy.ndarray
+    """
+
+    jet_pf_cands_ptyphim = akutl.ak_to_ptyphim(pf_cands, jet_idx)
+    
+    efpset = ef.EFPSet('d<='+str(degree), measure='hadr', beta=1, normed=True, verbose=False, coords="ptyphim")
+    efps = efpset.batch_compute(jet_pf_cands_ptyphim)
+
+    return tuple(efps.T)
+    
+
+def calculate_ecf_e2_1_jet(jet_idx, pf_cands, beta, sum_pfcands_pt=None, nan_value=-1):
+    """Calculate 2-point ECF for all jets of a given index for all events.
+
+    Args:
+        jet_idx (int)
+        pf_cands (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the PF
+            candidates axis with fields pt, rapidity, phi, mass and jetIdx,
+            and with name PtEtaPhiMLorentzVector.
+        beta (float):
+            angular exponent
+        sum_pfcands_pt (awkward.Array, optional, default=None):
+            Ak array where axis 0 is the event axis, axis 1 is the jet axis.
+            Sum of jet constituents pT for all jets in all events.
+            If None, will be computed from pf_cands.
+        nan_value (float, optional, default=-1):
+            Value to use when the event has less than jet_idx+1 jet(s).
+
+    Returns:
+        awkward.Array
+    """
+
+    jet_pf_cands = pf_cands[(pf_cands.jetIdx == jet_idx)]
+    combinations = ak.combinations(jet_pf_cands, 2, axis=1, fields=["i", "j"])
+    delta_r_ij = vecutl.delta_r(combinations.i, combinations.j, use_rapidity=True)
+    pti = combinations.i.pt
+    ptj = combinations.j.pt
+    ecf = ak.sum(pti*ptj*delta_r_ij**beta, axis=1)
+
+    if sum_pfcands_pt is not None:
+        ecf = akutl.divide_ak_arrays(ecf, sum_pfcands_pt[:, jet_idx]**2, division_by_zero_value=nan_value)
+    else:
+        ecf = akutl.divide_ak_arrays(ecf, calculate_sum_pfcands_pt_1_jet(jet_idx, pf_cands)**2, division_by_zero_value=nan_value)
+
+    return ecf
+
+
+def calculate_ecfs_e3_1_jet(jet_idx, pf_cands, beta, calculate_ecfgs=True, sum_pfcands_pt=None, nan_value=-1):
+    """Calculate 3-point generalized ECFs for all jets of a given index for all events.
+
+    Args:
+        jet_idx (int)
+        pf_cands (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the PF
+            candidates axis with fields pt, rapidity, phi, mass and jetIdx,
+            and with name PtEtaPhiMLorentzVector.
+        beta (float):
+            angular exponent
+        calculate_ecfgs (bool, optional, default=True):
+            False to calculate only 3e3, True for all generalized ECFs.
+        sum_pfcands_pt (awkward.Array, optional, default=None):
+            Ak array where axis 0 is the event axis, axis 1 is the jet axis.
+            Sum of jet constituents pT for all jets in all events.
+            If None, will be computed from pf_cands.
+        nan_value (float, optional, default=-1):
+            Value to use when the event has less than jet_idx+1 jet(s).
+
+    Returns:
+        awkward.Array
+    """
+
+    jet_pf_cands = pf_cands[(pf_cands.jetIdx == jet_idx)]
+    combinations = ak.combinations(jet_pf_cands, 3, axis=1, fields=["i", "j", "k"])
+    delta_r_ij = vecutl.delta_r(combinations.i, combinations.j, use_rapidity=True)
+    delta_r_ik = vecutl.delta_r(combinations.i, combinations.k, use_rapidity=True)
+    delta_r_jk = vecutl.delta_r(combinations.j, combinations.k, use_rapidity=True)
+    pti = combinations.i.pt
+    ptj = combinations.j.pt
+    ptk = combinations.k.pt
+    pt_product = pti * ptj * ptk
+
+    if calculate_ecfgs:
+        sorted_array = ak.sort([delta_r_ij, delta_r_ik, delta_r_jk], axis=0)
+        ecfgs_base = [pt_product] + 3 * [None]
+        ecfgs = 3 * [None]
+        for idx in range(1, 4):
+            ecfgs_base[idx] = ecfgs_base[idx-1] * sorted_array[idx-1]**beta
+            ecfgs[idx-1] = ak.sum(ecfgs_base[idx], axis=1)
+    else:
+        ecf = ak.sum(pt_product * (delta_r_ij*delta_r_ik*delta_r_jk)**beta, axis=1)
+
+    ## Normalize by the sum of constituents pT
+    if sum_pfcands_pt is not None:
+        norm = sum_pfcands_pt[:, jet_idx]**3
+    else:
+        norm = calculate_sum_pfcands_pt_1_jet(jet_idx, pf_cands)**3
+
+    if calculate_ecfgs:
+        for idx in range(3):
+            ecfgs[idx] = akutl.divide_ak_arrays(ecfgs[idx], norm, division_by_zero_value=nan_value)
+    else:
+        ecf = akutl.divide_ak_arrays(ecf, norm, division_by_zero_value=nan_value)
+
+    if calculate_ecfgs:
+        return tuple(ecfgs)
+    else:
+        return ecf
+
+
+def calculate_ecfs_e4_1_jet(jet_idx, pf_cands, beta, calculate_ecfgs=True, sum_pfcands_pt=None, nan_value=-1):
+    """Calculate 4-point generalized ECFs for all jets of a given index for all events.
+
+    Args:
+        jet_idx (int)
+        pf_cands (awkward.Array):
+            Ak array where axis 0 is the event axis, axis 1 is the PF
+            candidates axis with fields pt, rapidity, phi, mass and jetIdx,
+            and with name PtEtaPhiMLorentzVector.
+        beta (float):
+            angular exponent
+        calculate_ecfgs (bool, optional, default=True):
+            False to calculate only 6e4, True for all generalized ECFs.
+        sum_pfcands_pt (awkward.Array, optional, default=None):
+            Ak array where axis 0 is the event axis, axis 1 is the jet axis.
+            Sum of jet constituents pT for all jets in all events.
+            If None, will be computed from pf_cands.
+        nan_value (float, optional, default=-1):
+            Value to use when the event has less than jet_idx+1 jet(s).
+
+    Returns:
+        awkward.Array
+    """
+
+    jet_pf_cands = pf_cands[(pf_cands.jetIdx == jet_idx)]
+    combinations = ak.combinations(jet_pf_cands, 4, axis=1, fields=["i", "j", "k", "l"])
+    delta_r_ij = vecutl.delta_r(combinations.i, combinations.j, use_rapidity=True)
+    delta_r_ik = vecutl.delta_r(combinations.i, combinations.k, use_rapidity=True)
+    delta_r_il = vecutl.delta_r(combinations.i, combinations.l, use_rapidity=True)
+    delta_r_jk = vecutl.delta_r(combinations.j, combinations.k, use_rapidity=True)
+    delta_r_jl = vecutl.delta_r(combinations.j, combinations.l, use_rapidity=True)
+    delta_r_kl = vecutl.delta_r(combinations.k, combinations.l, use_rapidity=True)
+    pti = combinations.i.pt
+    ptj = combinations.j.pt
+    ptk = combinations.k.pt
+    ptl = combinations.l.pt
+    pt_product = pti * ptj * ptk * ptl
+
+    if calculate_ecfgs:
+        sorted_array = ak.sort([delta_r_ij, delta_r_ik, delta_r_il, delta_r_jk, delta_r_jl, delta_r_kl], axis=0)
+
+        ecfgs_base = [pt_product] + 6 * [None]
+        ecfgs = 6 * [None]
+        for idx in range(1, 7):
+            ecfgs_base[idx] = ecfgs_base[idx-1] * sorted_array[idx-1]**beta
+            ecfgs[idx-1] = ak.sum(ecfgs_base[idx], axis=1)
+    else:
+        ecf = ak.sum(pt_product * (delta_r_ij*delta_r_ik*delta_r_il*delta_r_jk*delta_r_jl*delta_r_kl)**beta, axis=1)
+
+    ## Normalize by the sum of constituents pT
+    if sum_pfcands_pt is not None:
+        norm = sum_pfcands_pt[:, jet_idx]**4
+    else:
+        norm = calculate_sum_pfcands_pt_1_jet(jet_idx, pf_cands)**4
+
+    if calculate_ecfgs:
+        for idx in range(6):
+            ecfgs[idx] = akutl.divide_ak_arrays(ecfgs[idx], norm, division_by_zero_value=nan_value)
+    else:
+        ecf = akutl.divide_ak_arrays(ecf, norm, division_by_zero_value=nan_value)
+
+    if calculate_ecfgs:
+        return tuple(ecfgs)
+    else:
+        return ecf
 
 
 def calculate_HEF_1_jet(charged, jet_idx, pf_cands, nan_value=-1):
@@ -184,7 +400,7 @@ def calculate_HEF_1_jet(charged, jet_idx, pf_cands, nan_value=-1):
             Value to use when the event has less than jet_idx+1 jet(s).
 
     Returns:
-        [awkward.Array]
+        awkward.Array
     """
 
     jet_pf_cands = pf_cands[(pf_cands.jetIdx == jet_idx)]
@@ -199,7 +415,7 @@ def calculate_HEF_1_jet(charged, jet_idx, pf_cands, nan_value=-1):
     denominator = ak.sum(jet_pf_cands.energy, axis=1)
     energy_fraction = akutl.divide_ak_arrays(numerator, denominator, division_by_zero_value=nan_value)
 
-    return [energy_fraction]
+    return energy_fraction
 
 
 def calculate_chHEF_1_jet(jet_idx, pf_cands, nan_value=-1):
@@ -220,7 +436,7 @@ def calculate_neHEF_1_jet(jet_idx, pf_cands, nan_value=-1):
     return calculate_HEF_1_jet(False, jet_idx, pf_cands, nan_value=-1)
 
 
-def calculate_jet_variable(variable, pf_cands, jets, njets, nan_value=-1):
+def calculate_jet_variable(variable, pf_cands, jets, njets=None, sum_pfcands_pt=None, nan_value=-1, jagged=True, params={}):
     """Return the desired calculated jet variable for all jets and all events.
 
     Args:
@@ -231,32 +447,60 @@ def calculate_jet_variable(variable, pf_cands, jets, njets, nan_value=-1):
         jets (awkward.Array or None):
             Ak array where axis 0 is the event axis, axis 1 is the jet axis
             with required field.
-        njets (awkward.Array or None):
+        njets (awkward.Array, optional, default=None):
             Ak array with one axis with number of jets in each event.
+            If None, will be computed from jets.
+        sum_pfcands_pt (awkward.Array, optional, default=None):
+            Ak array where axis 0 is the event axis, axis 1 is the jet axis.
+            Sum of jet constituents pT for all jets in all events.
+            If None, will be computed from jets in *_1_jet functions.
         nan_value (float, optional, default=-1):
             Value to use when the event has less than jet_idx+1 jet(s).
+        jagged (bool, optional, default=True):
+            Return a jagged (True) or rectangular (False) array.
+        params (dict, optional):
+            Parameters on which depend the function to compute the variable.
 
     Returns:
-        [awkward.Array]
+        awkward.Array or tuple[awkward.Array]
     """
+
+    if njets is None and jets is not None:
+        njets = ak.num(jets, axis=1)
 
     max_idx = get_max_jet_idx(pf_cands)
 
     for jet_idx in range(max_idx+1):
-        if variable == "ptD":
-            ak_arrays = calculate_ptD_1_jet(jet_idx, pf_cands, nan_value)
+        if variable == "sum_pfcands_pt":
+            ak_arrays = calculate_sum_pfcands_pt_1_jet(jet_idx, pf_cands)
+        elif variable == "ptD":
+            ak_arrays = calculate_ptD_1_jet(jet_idx, pf_cands, nan_value=nan_value)
         elif variable == "girth":
-            ak_arrays = calculate_girth_1_jet(jet_idx, pf_cands, jets, njets, nan_value)
+            ak_arrays = calculate_girth_1_jet(jet_idx, pf_cands, jets, njets, nan_value=nan_value)
         elif variable == "axes":
-            ak_arrays = calculate_axes_1_jet(jet_idx, pf_cands, jets, njets, nan_value)
+            ak_arrays = calculate_axes_1_jet(jet_idx, pf_cands, jets, njets, nan_value=nan_value)
+        elif variable == "efps":
+            ak_arrays = calculate_efps_1_jet(jet_idx, pf_cands, params["degree"])
+        elif variable == "ecf_e2":
+            ak_arrays = calculate_ecf_e2_1_jet(jet_idx, pf_cands, params["beta"], sum_pfcands_pt=sum_pfcands_pt, nan_value=nan_value)
+        elif variable == "ecfs_e3":
+            ak_arrays = calculate_ecfs_e3_1_jet(jet_idx, pf_cands, params["beta"], calculate_ecfgs=params["calculate_ecfgs"], sum_pfcands_pt=sum_pfcands_pt, nan_value=nan_value)
+        elif variable == "ecfs_e4":
+            ak_arrays = calculate_ecfs_e4_1_jet(jet_idx, pf_cands, params["beta"], calculate_ecfgs=params["calculate_ecfgs"], sum_pfcands_pt=sum_pfcands_pt, nan_value=nan_value)
         elif variable == "chHEF":
-            ak_arrays = calculate_chHEF_1_jet(jet_idx, pf_cands, nan_value)
+            ak_arrays = calculate_chHEF_1_jet(jet_idx, pf_cands, nan_value=nan_value)
         elif variable == "neHEF":
-            ak_arrays = calculate_neHEF_1_jet(jet_idx, pf_cands, nan_value)
+            ak_arrays = calculate_neHEF_1_jet(jet_idx, pf_cands, nan_value=nan_value)
         else:
             print("ERROR: Unknown variable %s. Exit!" %variable)
             sys.exit()
-        
+
+        if not isinstance(ak_arrays, tuple):
+            is_tuple = False
+            ak_arrays = (ak_arrays, )
+        else:
+            is_tuple = True
+
         if jet_idx == 0:
             ak_array_list = len(ak_arrays) * [ ak.Array([]) ]
         for idx, ak_array in enumerate(ak_arrays):
@@ -266,13 +510,28 @@ def calculate_jet_variable(variable, pf_cands, jets, njets, nan_value=-1):
     # instead of jets. Maybe there is something smarter than that.
     for idx, ak_array in enumerate(ak_array_list):
         ak_array = akutl.swap_axes(ak_array)
-        ak_array = ak_array[ak_array != nan_value][0]
+        if jagged:
+            ak_array = ak_array[ak_array != nan_value][0]
+        else:
+            ak_array = ak_array[0]
         ak_array_list[idx] = ak_array
 
-    return ak_array_list
+    if not is_tuple:
+        return ak_array_list[0]
+    else:
+        return ak_array_list
 
 
-def calculate_ptD(pf_cands):
+def calculate_sum_pfcands_pt(pf_cands, jagged=True):
+    """Return ECF1 for each jet for all events.
+
+    See doctring of calculate_sum_pfcands_pt.
+    """
+
+    return calculate_jet_variable("sum_pfcands_pt", pf_cands, None, None, nan_value=0., jagged=jagged)
+
+
+def calculate_ptD(pf_cands, jagged=True):
     """Return ptD for each jet for all events.
 
     See doctring of calculate_ptD_1_jet.
@@ -283,52 +542,156 @@ def calculate_ptD(pf_cands):
             candidates axis with fields pt and jetIdx.
     
     Returns:
-         [awkward.Array]
+         awkward.Array
 
     Examples:
-	>>> pf_cands_idx = ak.Array([[0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2]])
-	>>> pf_cands_pt = ak.Array([[280, 150, 150, 130, 70], [500, 300, 400, 300, 150, 100]])
+        >>> pf_cands_idx = ak.Array([[0, 0, 1, 1, 1], [0, 0, 1, 1, 2, 2]])
+        >>> pf_cands_pt = ak.Array([[280, 150, 150, 130, 70], [500, 300, 400, 300, 150, 100]])
         >>> pf_cands = ak.zip({"jetIdx": pf_cands_idx, "pt": pf_cands_pt})
         >>> ak.to_list(calculate_ptD(pf_cands)[0])
         [[0.739, 0.601], [0.729, 0.714, 0.721]]
     """
 
-    return calculate_jet_variable("ptD", pf_cands, None, None)
+    return calculate_jet_variable("ptD", pf_cands, None, None, jagged=jagged)
 
 
-def calculate_girth(pf_cands, jets, njets):
+def calculate_girth(pf_cands, jets, njets=None, jagged=True):
     """Return girth for each jet for all events.
     
     See doctring of calculate_girth_1_jet.
     """
 
-    return calculate_jet_variable("girth", pf_cands, jets, njets)
+    return calculate_jet_variable("girth", pf_cands, jets, njets=njets, jagged=jagged)
 
 
-def calculate_axes(pf_cands, jets, njets):
+def calculate_axes(pf_cands, jets, njets=None, jagged=True):
     """Return axis major, axis minor and axis avg for each jet for all events.
 
     See doctring of calculate_axes_1_jet.
     """
 
-    return calculate_jet_variable("axes", pf_cands, jets, njets)
+    return calculate_jet_variable("axes", pf_cands, jets, njets=njets, jagged=jagged)
 
 
-def calculate_chHEF(pf_cands, jets, njets):
+def calculate_efps(pf_cands, degree, jagged=True):
+    """Return EFPs up to a certain degree for each jet for all events.
+
+    See doctring of calculate_efps_1_jet.
+    """
+
+    return calculate_jet_variable("efps", pf_cands, None, nan_value=0, jagged=jagged, params={"degree": degree})
+
+
+def calculate_ecf_e2(pf_cands, beta, sum_pfcands_pt=None, jagged=True):
+    """Return ECF2 for each jet for all events.
+
+    See doctring of calculate_ecf_e2_1_jet.
+    """
+
+    return calculate_jet_variable("ecf_e2", pf_cands, None, sum_pfcands_pt=sum_pfcands_pt, nan_value=-1, jagged=jagged, params={"beta": beta})
+
+
+def calculate_ecfs_e3(pf_cands, beta, sum_pfcands_pt=None, jagged=True, calculate_ecfgs=True):
+    """Return ECF3 for each jet for all events.
+
+    See doctring of calculate_ecf_e3_1_jet.
+    """
+
+    return calculate_jet_variable("ecfs_e3", pf_cands, None, sum_pfcands_pt=sum_pfcands_pt, nan_value=-1, jagged=jagged, params={"beta": beta, "calculate_ecfgs": calculate_ecfgs})
+
+
+def calculate_ecfs_e4(pf_cands, beta, sum_pfcands_pt=None, jagged=True, calculate_ecfgs=True):
+    """Return ECF4 for each jet for all events.
+
+    See doctring of calculate_ecf_e4_1_jet.
+    """
+
+    return calculate_jet_variable("ecfs_e4", pf_cands, None, sum_pfcands_pt=sum_pfcands_pt, nan_value=-1, jagged=jagged, params={"beta": beta, "calculate_ecfgs": calculate_ecfgs})
+
+
+def calculate_chHEF(pf_cands, jets, njets=None, jagged=True):
     """Return charged hadron energy fraction for each jet for all events.
     
     See doctring of calculate_HEF_1_jet.
     """
 
-    return calculate_jet_variable("chHEF", pf_cands, jets, njets)
+    return calculate_jet_variable("chHEF", pf_cands, jets, njets=njets, jagged=jagged)
 
 
-def calculate_neHEF(pf_cands, jets, njets):
+def calculate_neHEF(pf_cands, jets, njets=None, jagged=True):
     """Return neutral hadron energy fraction for each jet for all events.
 
     See doctring of calculate_HEF_1_jet.
     """
 
-    return calculate_jet_variable("neHEF", pf_cands, jets, njets)
+    return calculate_jet_variable("neHEF", pf_cands, jets, njets=njets, jagged=jagged)
 
 
+
+def calculate_ecf_c(ei, ej, ek):
+    """Calculate C-series ECFs.
+    
+    ei (resp. ej, ek) is the i-point (resp. j-point, k-point) normalized ECF.
+    To calculate C-series ECFs: j=i+1 and k=i+2.
+
+    Args:
+        ei (awkward.Array): i-point ECF
+        ej (awkward.Array): j-point ECF
+        ek (awkward.Array): k-point ECF
+
+    Returns:
+        awkward.Array
+    """
+
+    return ei*ek/ej**2
+
+def calculate_ecf_d(ei, ej, ek):
+    """Calculate D-series ECFs.
+    
+    ei (resp. ej, ek) is the i-point (resp. j-point, k-point) normalized ECF.
+    To calculate D-series ECFs: j=i+1 and k=i+2.
+
+    Args:
+        ei (awkward.Array): i-point ECF
+        ej (awkward.Array): j-point ECF
+        ek (awkward.Array): k-point ECF
+
+    Returns:
+        awkward.Array
+    """
+
+    return ei**3*ek/ej**3
+
+def calculate_ecf_m(v1ei, v1ej):
+    """Calculate M-series ECFs.
+    
+    v1ei (resp. v1ej) is the first i-point (resp. j-point) normalized
+    generalized ECFs.
+    To calculate M-series ECFs: j=i+1.
+
+    Args:
+        v1ei (awkward.Array): 1st i-point ECFG
+        v1ej (awkward.Array): 1st j-point ECFG
+
+    Returns:
+        awkward.Array
+    """
+
+    return v1ej/v1ei
+
+def calculate_ecf_n(v1ei, v2ej):
+    """Calculate N-series ECFs.
+    
+    v1ei (resp. v2ej) is the first i-point (resp.i second j-point) normalized
+    generalized ECFs.
+    To calculate N-series ECFs: j=i+1.
+
+    Args:
+        v1ei (awkward.Array): 1st i-point ECFG
+        v2ej (awkward.Array): 2nd j-point ECFG
+
+    Returns:
+        awkward.Array
+    """
+
+    return v2ej/v1ei**2


### PR DESCRIPTION
### Some changes discussed in the last PR (https://github.com/jniedzie/SVJanalysis/pull/18):
   * In `utilities/variablesComputation/awkwardArray/jetVariables.py`: Return ak.Array or tuple of ak.Array instead of lists

I did not rename the imported packages (yet!).

### New branches calculations
   * In `utilities/variablesComputation/awkwardArray/jetVariables.py`:
      * ECFs (only "pure ECFs", generalized ECFs, C, D, M, and N series)
      * EFPs
   * In `utilities/variablesComputation/awkwardArray/eventVariables.py`
      * Razor variables : M_R, M^R_T and R
   * In `utilities/awkwardArrayUtilities.py`: Transform jet constituents ak.Array into list of pt, rapidity, phi, mass (needed for EFPs)
   * In `utilities/PtEtaPhiMLorentzVectorUtilities.py`:
      * Calculation of rapidity (needed for EFPs)
      * Calculation of delta R using rapidity instead of pseudorapidity eta (needed for ECFs)
      * Calculation of the momentum along z and magnitude (needed for Razor variables).
   * In `BranchesProducer.py`:
      * Simplifications in `__init__`
      * Calculation and accumulation for the new variables
      * Addition of `get_met` to make an ak.Array for the MET

### Addition of a script to simplify name translations
e.g. `AK4` to `Jet`, `AK8` to `FatJet`
   * `utilities/nameUtilities.py`