### PR TITLE
Update of the pre-selection code for converting NTuples into PFNanoAOD format

### DIFF
--- a/preSelection/makePreSelection.py
+++ b/preSelection/makePreSelection.py
@@ -1,175 +1,126 @@
 from coffea import processor
-#from coffea.nanoevents import PFNanoAODSchema
 from coffea.nanoevents import NanoAODSchema
-import awkward as ak
-import awkward0 as ak0
 import uproot3
 import numpy as np
+import sys
 import os
 import time
 import argparse
 from collections import OrderedDict
 
+sys.path.append("../utilities/")
+import uproot3Utilities as uproot3utl
 import processorPreSelection
 
 
 def print_cutflow(cutflow):
-    """
-    Print cut efficiencies for cuts needed for defining some of the variables.
-    E.g. for deltaR between leading 2 jets, events needs to have at least 2 jets.
+    """Print cut efficiencies for cuts needed for defining some of the variables.
+
+    For instance, to compute deltaR between leading 2 jets, events needs
+    to have at least 2 jets.
+
+    Args:
+        cutflow (dict[coffea.processor.defaultdict_accumulator]):
+            Keys are cut names
+            Values are numbers of processed events (sum of gen weights)
+ 
+    Returns:
+        dict[float]
+            Keys are cut names
+            Values are absolute efficiencies
     """
 
-    lenCol1 = max([ len(k) for k in cutflow.keys() ])
-    efficiencies = OrderedDict()
+    len_column1 = max([ len(k) for k in cutflow.keys() ])
+    efficiencies = {}
 
     print("\nCutflow:")
-    print("\tCut" + (lenCol1-3)*" " + "  Abs. eff. [%]   Rel. eff. [%]")
-
-    nAll = cutflow["all"]
+    print("\tCut" + (len_column1-3)*" " + "  Abs. eff. [%]   Rel. eff. [%]")
+    n_all = cutflow["all"]
     for cut, n in cutflow.items():
         if cut != "all":
-            absoluteEfficiency = 100*n/nAll
-            if nPreviousCut > 0.:
-                relativeEfficiency = 100*n/nPreviousCut
+            absolute_efficiency = 100*n/n_all
+            if n_previous_cut > 0.:
+                relative_efficiency = 100*n/n_previous_cut
             else:
-                relativeEfficiency = np.nan
-            spaces = (lenCol1-len(cut)+(absoluteEfficiency<10))*" "
-            print("\t%s%s  %.2f           %.2f" %(cut, spaces, absoluteEfficiency, relativeEfficiency))
-            efficiencies[cut] = absoluteEfficiency/100
-        nPreviousCut = n
+                relative_efficiency = np.nan
+            spaces = (len_column1-len(cut)+(absolute_efficiency<10))*" "
+            print("\t%s%s  %.2f           %.2f" %(cut, spaces, absolute_efficiency, relative_efficiency))
+            efficiencies[cut] = absolute_efficiency/100
+        n_previous_cut = n
     
-    efficiencies["totalEfficiency"] = absoluteEfficiency
-    
+    efficiencies["totalEfficiency"] = absolute_efficiency
+ 
     return efficiencies
 
 
-def delete_empty_fields(accumulator, debug):
-    """ ... """
+def write_root_file(output_file, events, efficiencies, debug):
+    """Write ROOT file with Events and Efficiencies TTrees.
 
-    deletion = False
-    if debug: print("\nDeleting empty fields...")
+    Args:
+        output_file (str)
+        events (coffea.processor.accumulator.dict_accumulator)
+            Keys are Events branch names
+            Values are branches (coffea.processor.accumulator.column_accumulator)
+        efficiencies (dict[float])
+            Keys are Efficicies branch names
+            Values are efficiencies (float)
+        debug (bool)
 
-    keys_to_delete = []
-    for key, column in accumulator.items():
-        if column.value.shape[0] == 0:
-            keys_to_delete.append(key)
-            if debug:
-                deletion = True
-                print("%s is empty. Deleting from accumulator." %key)
-
-    if debug:
-        if not deletion:
-            print("No empty field in accumulator.")
-        print("")
-        
-    for key in keys_to_delete: accumulator.pop(key)
-
-    return
-      
-
-def make_events_branches(accumulator, debug):
-    """Make branches for Events tree."""
-
-    branches = {}
-    branchesInit = {}
-    lenKeys = []
-
-    # Finding keys giving the length of jagged arrays
-    for k, v in accumulator.items():
-        nKey = "n"+str(k.split("_")[0])
-        if (not k.startswith("n")) and (nKey in accumulator.keys()):
-            lenKeys.append(nKey)
-
-    # Making branches
-    # Need to use ak0 because it is not yet implemented in uproot4 i.e. ak1 (Feb. 2021)
-    for k, v in accumulator.items():
-        if debug:
-            print("%s: %s" %(k, ak.type(ak.Array(v.value))))
-        if not k.startswith("n"):
-            nKey = "n"+str(k.split("_")[0])
-            if nKey in lenKeys:
-                branches[k] = ak.to_awkward0(ak.Array(v.value))
-                # Case distinction for type of the jagged-array collections, treated as "object" in the processor
-                # _candIdx and _jetIdx must be saved as integers ("i4") to use array at once syntax like 
-                #     jetIdx = (events.JetPFCandsAK4_jetIdx == ijet)
-                #     candIdx = events.JetPFCandsAK4_candIdx[jetIdx]
-                #     PFcands_eta = events.JetPFCands_eta[candIdx]
-                if k.endswith("_pFCandsIdx") or k.endswith("_jetIdx"):
-                    branchesInit[k] = uproot3.newbranch(np.dtype("i4"), size=nKey)
-                else:
-                    branchesInit[k] = uproot3.newbranch(np.dtype("f8"), size=nKey)
-            else:
-                branches[k] = ak.to_awkward0(ak.Array(v.value))
-                branchesInit[k] = uproot3.newbranch(v.value.dtype)
-        else:
-            if k in lenKeys:
-                branches[k] = ak.to_awkward0(ak.Array(v.value))
-            else:
-                branches[k] = ak.to_awkward0(ak.Array(v.value))
-                branchesInit[k] = uproot3.newbranch(v.value.dtype)
-
-    return branches, branchesInit
-
-
-def make_efficiencies_branches(efficiencies):
-    """Make branches for Efficiencies tree."""
-
-    branches = {}
-    branchesInit = {}
-
-    for k, v in efficiencies.items():
-        branchesInit[k] = np.dtype("f8")
-        branches[k] = np.array([v])
-
-    return branches, branchesInit
-
-
-def write_root_file(accumulator, outputFile, efficiencies, debug):
-    """
-    2 trees are written:
-       * Events: standard NTuple events tree
-       * Cuts: a tree with one branch `Efficiency`, having only one leaf, representing pre-selection efficiency
+    Returns:
+        None
     """
 
     # Making branches to write to Events tree
-    branchesEvents, branchesInitEvents = make_events_branches(accumulator, debug)
-    branchesEfficiencies, branchesInitEfficiencies = make_efficiencies_branches(efficiencies)
+    branches_events, branches_init_events = uproot3utl.make_branches(events, debug)
+    branches_efficiencies, branches_init_efficiencies = uproot3utl.make_branches(efficiencies, debug)
 
     if debug:
         print("\nEvents branches keys:")
-        print(branchesEvents.keys())
+        print(branches_events.keys())
         print("\nEvents branchesInit keys:")
-        print(branchesInitEvents.keys())
+        print(branches_init_events.keys())
 
 
-    # Save branches to ROOT file
-    # Need to use uproot3 because it is not implemented yet in uproot4 (Feb. 2021)
-    with uproot3.recreate(outputFile) as f:
-        f["Events"] = uproot3.newtree(branchesInitEvents)
-        f["Events"].extend(branchesEvents)
-        print("\nTTree Events saved to output file %s" %outputFile)
+    with uproot3.recreate(output_file) as root_file:
+        # Save events to output ROOT file
+        uproot3utl.write_tree_to_root_file(root_file, "Events", branches_events, branches_init_events)
+        print("\nTTree Events saved to output file %s" %output_file)
 
-        # Save cut efficiency to ROOT file
-        f["Efficiencies"] = uproot3.newtree(branchesInitEfficiencies)
-        f["Efficiencies"].extend(branchesEfficiencies)
-        print("TTree Efficiencies saved to output file %s" %outputFile)
+        # Save cut efficiencies to output ROOT file
+        uproot3utl.write_tree_to_root_file(root_file, "Efficiencies", branches_efficiencies, branches_init_efficiencies)
+        print("TTree Efficiencies saved to output file %s" %output_file)
 
     return
 
 
-def main(inputFiles, outputFile, fileType, processorName, chunksize, maxchunks, nworkers, debug):
+def main(input_files, output_file, file_type, processor_name, chunksize, maxchunks, nworkers, debug):
+    """Produce ROOT file with pre-selected events.
+    
+    Args:
+        input_files (list[str])
+        output_file (str)
+        file_type (str)
+        processor_name (str)
+        chunksize (int)
+        maxchunks (int or None)
+        nworkers (int)
+        debug (bool)
+
+    Returns:
+        None
+    """
 
     print("Input files:")
-    print(inputFiles)
+    print(input_files)
 
     ## Fileset
-    fileset = { "fileset": inputFiles }
+    fileset = { "fileset": input_files }
 
     ## Make pre-selections
-    output = processor.run_uproot_job(
+    accumulator = processor.run_uproot_job(
         fileset,
         treename = "Events",
-        processor_instance = getattr(processorPreSelection, processorName)(fileType),
+        processor_instance = getattr(processorPreSelection, processor_name)(file_type),
         executor = processor.iterative_executor,
         executor_args = {"schema": NanoAODSchema, "workers": nworkers},
         chunksize = chunksize,
@@ -177,18 +128,16 @@ def main(inputFiles, outputFile, fileType, processorName, chunksize, maxchunks, 
         )
 
     ## Print out cutflow
-    cutflow = output.pop("cutflow")
+    cutflow = accumulator.pop("cutflow")
     efficiencies = print_cutflow(cutflow)
-
-
-    ## Delete empty fields
-    delete_empty_fields(output, debug)
 
     ## Making output ROOT file
     if efficiencies["totalEfficiency"] == 0.:
         print("\nWARNING: 0 event passed pre-selections. Will not write an empty ROOT file.")
     else:
-        write_root_file(output, outputFile, efficiencies, debug)
+        write_root_file(output_file, accumulator, efficiencies, debug)
+
+    return
 
 
 if __name__ == "__main__":
@@ -269,13 +218,8 @@ if __name__ == "__main__":
         inputFiles = [ x.replace("\n", "") for x in inputFiles ]
         inputFiles = [ x for x in inputFiles if x.endswith(".root") ]
 
-    if args.debug:
-        debug = True
-    else:
-        debug = False
-
     ## Make pre-selection
-    main(inputFiles, args.output, args.fileType, args.processor, args.chunksize, args.maxchunks, args.nworkers, debug)
+    main(inputFiles, args.output, args.fileType, args.processor, args.chunksize, args.maxchunks, args.nworkers, args.debug)
 
 
     elapsed = time.time() - tstart

--- a/preSelection/objects.py
+++ b/preSelection/objects.py
@@ -5,18 +5,25 @@ import sys
 sys.path.append("../utilities/")
 import nameUtilities as nameutl
     
-## TODO: doctrings
 
 ## Functions needed to take care of the reindixing of jets
 ## e.g. modification of *_jetIdx variables due to good jets selection
 
 def true_indices(ak_array):
-    """
-    Input: ak array with boolean values corresponding with structure of a branch of an Events tree
-           or an iterable with similar jagged structure.
-           e.g. [ [True, False, True], [True], [], [False, True] ]
-    Return a jagged list with indices of the jagged array that are true.
-           e.g. [ [0, 3], [0], [], [1] ]
+    """Returns True indice in jagged array.
+
+    Args:
+        ak_array (awkard.highlevel.Array[bool]): 2D ak array with boolean values
+           with structure of a branch of an Events tree or an iterable with
+           similar jagged structure.
+
+    Returns:
+        list[list[int]]: a jagged list with indices of the jagged array that are true.
+
+    Examples:
+        >>> ak_array = [ [True, False, True], [True], [], [False, True] ]
+        >>> true_indices(ak_array)
+        [ [0, 2], [0], [], [1] ]
     """
 
     true_indices = [ [ idx for idx, x in enumerate(y) if x ] for y in ak_array ]
@@ -25,37 +32,53 @@ def true_indices(ak_array):
         
 def is_in(array1, array2):
     """
-    Input: 2 jagged arrays
-    Return a boolean jagged array
-    e.g. array1 = [ [0, 1, 1, 2, 2, 3], [0, 0, 1], [0, 1, 1, 2] ]
-         array2 = [ [0, 3], [], [0, 2] ]
-         return [ [True, False, False, False, False, True], [False, False, False] [True, False, False, True]]
+    Args:
+        array1 (awkard.highlevel.Array[int])
+        array2 (awkard.highlevel.Array[int])
+
+    Returns:
+        awkard.highlevel.Array[bool]
+
+    Examples:
+        >>> array1 = [ [0, 1, 1, 2, 2, 3], [0, 0, 1], [0, 1, 1, 2] ]
+        >>> array2 = [ [0, 3], [], [0, 2] ]
+        >>> is_in(array1, array2)
+        [ [True, False, False, False, False, True], [False, False, False] [True, False, False, True]]
     """
 
     return ak.Array([ [ True if x in y2 else False for x in y1 ] for y1, y2 in zip(array1, array2) ])
 
 
 def discrete_function(X, Y, x):
-    """
-    Input X = (x1, x2, ..., xn)
-          Y = (y1, y2, ..., yn)
-          x in X
-    Discrete function f(xi) = yi 
-    Return f(x)
+    """Discrete function f(xi) = yi.
+
+    Args:
+        X (list[T], tuple[T], array[T]): (x1, x2, ..., xn)
+        Y (list[U], tuple[U], array[U]): (y1, y2, ..., yn)
+        x (T): element in X
+    
+    Returns:
+        U: f(x) = y
     """
 
     X = list(X)
     Y = list(Y)
     idx = X.index(x)
+
     return Y[idx]
 
 
 def make_new_jet_indices(filter_, jet_indices):
-    """
-    Input:
-      * filter_   : jagged array with boolean values corresponding the selected jets
-      * jetIndices: jagged array with jet indices
-    Return jagged array of jet indices for selected jets
+    """Update jet indices after selecting some jets.
+
+    Args
+        filter_ (awkard.highlevel.Array):
+            jagged array with boolean values corresponding the selected jets
+        jetIndices (awkard.highlevel.Array): 
+            jagged array with jet indices
+
+    Returns:
+        awkard.highlevel.Array: jagged array of jet indices for selected jets
     """
 
     new_jet_indices = []
@@ -68,17 +91,18 @@ def make_new_jet_indices(filter_, jet_indices):
     return ak.Array(new_jet_indices)
 
 
-def count(ak_array, axis=1):
-    """Returns None if ak array is empty, else returns ak.count."""
-
-    if ak.size(ak.flatten(ak_array)) == 0:
-        return None
-    else:
-        return ak.count(ak_array, axis=axis)
-
-
 def make_ak_array_collection(collection, variables):
-    """ ... """
+    """Make jagged array with fields.
+
+    Args:
+        collection (object having awkward.highlevel.Array attributes)
+        variables (dict[str]):
+            Keys are attributes names of the object collection
+            Values are fields names to use in the ak array
+
+    Returns:
+        awkward.highlevel.Array
+    """
 
     return ak.zip({
                final_variable_name: getattr(collection, initial_variable_name)
@@ -88,10 +112,19 @@ def make_ak_array_collection(collection, variables):
 
 
 
-class GoodJets():
-    """Make collection of good AK8 jets."""
+class Jets():
 
     def __init__(self, events, jet_algo_name, input_file_type, cut=None):
+        """
+        Args:
+            events (awkward.highlevel.Array): the Events TTree opened with uproot
+            jet_algo_name (str)
+            input_file_type (str)
+            cut (str or None)
+
+        Returns:
+            None
+        """
 
         if input_file_type == "PFNanoAOD_106X_v01" or input_file_type == "PFNanoAOD_106X_v02":
             jet_collection_name = nameutl.jet_algo_name_to_jet_collection_name(jet_algo_name)
@@ -140,6 +173,14 @@ class GoodJets():
 
 
     def apply_cut(self, cut):
+        """
+        Args:
+            cut (awkward.highlevel.Array[bool])
+
+        Returns:
+            None
+        """
+
         self.jet = self.jet[cut]
         self.n = self.n[cut]
         self.filter_ = self.filter_[cut]
@@ -199,17 +240,16 @@ class GoodJets():
 
 
 
-class GoodPfCands():
+class PfCands():
 
     def __init__(self, events, input_file_type):
-        """Get .
-
+        """
         Args:
-            events (ak.Array): the Events TTree opened with uproot.
+            events (awkward.highlevel.Array): the Events TTree opened with uproot
             input_file_type (str)
 
         Returns:
-            awkward.Array: ak array with fields 
+            None
         """
 
         ## For PF nano AOD 106X and master branches
@@ -276,10 +316,19 @@ class GoodPfCands():
 
 
 
-class GoodJetPfCandsMatchingTable():
-    """..."""
+class JetPfCandsMatchingTable():
 
     def __init__(self, events, good_jets, jet_algo_name, input_file_type):
+        """
+        Args:
+            events (awkward.highlevel.Array): the Events TTree opened with uproot
+            good_jets (Jets)
+            jet_algo_name (str)
+            input_file_type (str)
+
+        Returns:
+            None
+        """
 
         if input_file_type == "PFNanoAOD_106X_v01" or input_file_type == "PFNanoAOD_106X_v02":
 
@@ -303,7 +352,7 @@ class GoodJetPfCandsMatchingTable():
             # Get PF candidates indices in good fat jets
             self.pFCandsIdx = getattr(table, cand_idx_name)[self.filter_]
             # Number of PF candidates
-            self.n = count(self.jetIdx, axis=1)
+            self.n = ak.count(self.jetIdx, axis=1)
 
         self.variables = ["jetIdx", "pFCandsIdx"]
 

--- a/preSelection/objects.py
+++ b/preSelection/objects.py
@@ -112,6 +112,77 @@ def make_ak_array_collection(collection, variables):
 
 
 
+class SingleEventLevel():
+
+    def __init__(self, events, input_file_type):
+        """
+        Args:
+            events (awkward.highlevel.Array): the Events TTree opened with uproot
+            input_file_type (str)
+
+        Returns:
+            None
+        """
+
+        if input_file_type == "PFNanoAOD_106X_v01" or input_file_type == "PFNanoAOD_106X_v02":
+            self.event_level = ak.zip({
+                "genWeight": events.genWeight
+            })
+        else:
+            # Define here self.event_level
+            pass
+
+        self.variables = self.event_level.fields
+
+
+    @property
+    def genWeight(self):
+        return self.event_level.genWeight
+
+
+
+class Met():
+
+    def __init__(self, events, met_flavor, input_file_type):
+        """
+        Args:
+            events (awkward.highlevel.Array): the Events TTree opened with uproot
+            input_file_type (str)
+            met_flavor (str): e.g. MET, PuppiMET
+
+        Returns:
+            None
+        """
+
+        ## For PF nano AOD 106X and master branches
+        if input_file_type == "PFNanoAOD_106X_v01" or input_file_type == "PFNanoAOD_106X_v02":
+            met = getattr(events, met_flavor)
+            met_variables = {
+                "phi"  : "phi",
+                "pt"   : "pt",
+                "sumEt": "sumEt",
+            }
+        else:
+            # Define here met and met_variables
+            pass
+
+        self.met = make_ak_array_collection(met, met_variables)
+        self.variables = self.met.fields
+
+
+    @property
+    def pt(self):
+        return self.met.pt
+
+    @property
+    def phi(self):
+        return self.met.phi
+
+    @property
+    def sumEt(self):
+        return self.met.sumEt
+
+
 class Jets():
 
     def __init__(self, events, jet_algo_name, input_file_type, cut=None):

--- a/preSelection/runMakePreSelection.sh
+++ b/preSelection/runMakePreSelection.sh
@@ -1,16 +1,6 @@
 #!/bin/bash
 
-sepath=/pnfs/psi.ch/cms/trivcat/store/user/fleble
+input_file=/pnfs/psi.ch/cms/trivcat/store/user/fleble/SVJ/t_channel/samples/2018/PFNANOAOD/step5_PFNANOAOD_t-channel_mMed-3000_mDark-20_rinv-0.3_alpha-peak_yukawa-1_13TeV-madgraphMLM-pythia8_n-1000_part-1.root
 
-chunksize=10000
+python makePreSelection.py -i ${input_file} -o test.root -t PFNanoAOD_106X_v02 -p Preselection_tchannel
 
-mMed=3000
-mDark=20
-rinv=0.3
-alpha=peak
-
-var=mMed-${mMed}_mDark-${mDark}_rinv-${rinv}_alpha-${alpha}_yukawa-1_13TeV-madgraphMLM-pythia8
-ifile=${sepath}/SVJ/t_channel/samples/102X/${var}/NANOAODJMAR/merged.root
-ofile=./test.root
-
-python makePreSelection.py -i ${ifile} -o ${ofile} -t PFnano102X -c ${chunksize} -p Preselection_tchannel

--- a/utilities/uproot3Utilities.py
+++ b/utilities/uproot3Utilities.py
@@ -1,0 +1,136 @@
+import numpy as np
+import awkward as ak
+import uproot3
+
+
+def obj_to_ak_array(obj):
+    """Convert any input type to an awkward array.
+
+    Args:
+        obj (any type convertible to ak array)
+
+    Returns:
+        awkward.highlevel.Array
+    """
+
+    if isinstance(obj, ak.highlevel.Array):
+        ak_array = obj
+    elif isinstance(obj, np.ndarray):
+        ak_array = ak.Array(obj)
+    elif isinstance(obj, np.float32) or isinstance(obj, np.float64) or isinstance(obj, np.int32) or isinstance(obj, np.int64) \
+         or isinstance(obj, float) or isinstance(obj, int):
+        ak_array = ak.Array([obj])
+    else:
+        print("Unknown type %s" %(type(obj)))
+
+    return ak_array
+
+
+def get_size_branch_names(tree):
+    """Find the names of branches storing the size of jagged array branches.
+
+    By convention they are called n<CollectionName>.
+    E.g. nJet is the name of the size branch for Jet_pt.
+
+    Args:
+        tree (dict or coffea.processor.dict_accumulator)
+            Keys are the names of the branches in the tree
+
+    Returns:
+        list[str]
+    """
+
+    size_branch_names = []
+    for branch_name, branch in tree.items():
+        nbranch_name = "n"+str(branch_name.split("_")[0])
+        if (not branch_name.startswith("n")) and (nbranch_name in tree.keys()) and (nbranch_name not in size_branch_names):
+            size_branch_names.append(nbranch_name)
+
+    return size_branch_names
+
+
+def make_branches(tree, debug=False):
+    """Make branches and branches initailiazer to write a tree to a ROOT file.
+
+    Args:
+        tree (dict[awkward.Array] or coffea.processor.dict_accumulator)
+        debug (bool)
+
+    Returns:
+        tuple: (dict[awkward0.array.jagged.JaggedArray], dict[uproot3.write.objects.TTree.newbranch])
+    """
+
+    ## Running sanity checks
+    tree_type = str(type(tree)).split("'")[1]
+    allowed_tree_types = ["dict", "coffea.processor.accumulator.dict_accumulator"]
+    if tree_type not in allowed_tree_types:
+        print("ERROR: Unknown tree type: %s" %tree_type)
+        print("       Allowed tree types:")
+        for type_ in allowed_tree_types: print("\t%s" %type_)
+        return None, None
+
+    ## Book dict to return
+    branches = {}
+    branches_init = {}
+
+    ## Find names of the branches storing the size of jagged array branches
+    size_branch_names = get_size_branch_names(tree)
+    if debug:
+        print("Size branch names: ", size_branch_names)
+
+    ## Making branches and branches_init
+    #  Need to use ak0 and uproot3 because writing tree to ROOT file is not yet implemented in uproot4 (Feb. 2021)
+    for branch_name, branch in tree.items():
+
+        if tree_type == "coffea.processor.accumulator.dict_accumulator":
+            branch = branch.value
+            dtype = branch.dtype
+            branch = obj_to_ak_array(branch)
+        elif tree_type == "dict":
+            branch = obj_to_ak_array(branch)
+            dtype = ("%s" %ak.type(branch)).split("*")[-1][1:]
+
+        if debug:
+            print("%s: %s" %(branch_name, ak.type(branch)))
+
+
+        # Defining branch
+        branches[branch_name] = ak.to_awkward0(branch)
+
+        # Defining branch_init
+        if not branch_name.startswith("n"):
+            nbranch_name = "n"+str(branch_name.split("_")[0])
+            if nbranch_name in size_branch_names:
+                # Case distinction for type of the jagged-array collections, treated as "object" in the processor
+                # _pFCandsIdx and _jetIdx must be saved as integers ("i4") to use array at once syntax
+                if branch_name.endswith("Idx"):
+                    branches_init[branch_name] = uproot3.newbranch(np.dtype("i4"), size=nbranch_name)
+                else:
+                    branches_init[branch_name] = uproot3.newbranch(np.dtype("f8"), size=nbranch_name)
+            else:
+                branches_init[branch_name] = uproot3.newbranch(dtype)
+        else:
+            if branch_name not in size_branch_names:
+                branches_init[branch_name] = uproot3.newbranch(dtype)
+
+    return branches, branches_init
+
+
+def write_tree_to_root_file(file_, tree_name, branches, branches_init):
+    """Write histograms, stored in a coffea accumulator, to a ROOT file.
+
+    Args:
+        accumulator (coffea.processor.dict_accumulator)
+        output_file_name (str): Name of the ROOT file to create
+        debug (bool)
+
+    Returns:
+        None
+    """
+
+    file_[tree_name] = uproot3.newtree(branches_init)
+    file_[tree_name].extend(branches)
+
+    return
+
+


### PR DESCRIPTION
### Update of the pre-selection code so that it is structured in a way that makes it possible to convert any ROOT NTuples format into PFNanoAOD ROOT NTuple format.

The idea is that the conversion is absorbed into the definition of the Jets, PfCands, JetPfCandsMatchingTable objects, defined in `objects.py`, so that the coffea processor and the application of cuts is independent of the input file type.    
Example: For jets, one must define `self.jets` and `self.variables` so that `self.jets` is an ak array where the different jet variables are stored under different fields, listed in `self.variables`.     
The fields names (i.e. collection variables, e.g. jet variables in the previous example) are fixed by the conventions used in PFNanoAOD.    
For simplicity, getters for the collection variables are defined.

### Tree writer to ROOT files
Creation of `utilities/uproot3Utilities.py`, with the relevant code the write ak arrays into a ROOT file. In particular, this makes it possible to write coffea output into a ROOT file.