### PR TITLE
Some refactoring / code improvement of `uproot3Utilities.py` and addition of ROOT NTuples merger

### DIFF
--- a/nTuplesMerger/mergeNTuples.py
+++ b/nTuplesMerger/mergeNTuples.py
@@ -1,0 +1,204 @@
+from coffea import processor
+from coffea.nanoevents import BaseSchema
+import awkward as ak
+import uproot
+import uproot3
+import numpy as np
+import time
+import argparse
+import sys
+
+sys.path.append("../utilities/")
+import uproot3Utilities as uproot3utl
+
+
+def make_files_list(files_arg):
+    """ ... """
+
+    # If list of ROOT files in txt file
+    if not files_arg.endswith(".root"):
+        with open (files_arg, "r") as txt_file:
+            root_files = [ x.replace("\n", "") for x in txt_file.readlines() ]
+    # Else we assume coma separated list of ROOT files
+    else:
+        root_files = files_arg.split(",")
+
+    return root_files
+
+
+def make_branches_to_read(file_names, tree_name):
+    """ ... """
+
+    branches_to_read = {}
+    branches_names_added = []
+    for ifile, file_name in enumerate(file_names):
+        file_ = uproot3.open(file_name)
+        tree = file_[tree_name]
+        branches_this_file = [ branch.decode("utf-8") for branch in tree.keys() ]
+        branches_to_read[file_name] = [ branch_name for branch_name in branches_this_file if branch_name not in branches_names_added ]
+        branches_names_added = branches_names_added + branches_to_read[file_name]
+
+    return branches_to_read
+
+def get_all_branches_name(file_name, tree_name):
+    """ ... """
+
+    tree = uproot3.open(file_name)[tree_name]
+    branches_to_read = [ branch.decode("utf-8") for branch in tree.keys() ]
+
+    return branches_to_read
+
+
+def write_root_file(trees, merging_algos, output_file_name, debug):
+    """Write histograms, stored in a coffea accumulator, to a ROOT file.
+
+    Args:
+        trees (dict[dict[awkward.highlevel.Array]])
+            1st key is tree name
+            2nd key is branch name
+            Value is the branch (ak array)
+        merging_algos (list[str])
+        output_file_name (str)
+        debug (bool)
+
+    Returns:
+        None
+    """
+
+    # Need to use compression=None because there is a bug with EFPs when the file is compressed:
+    # More info at https://github.com/scikit-hep/uproot3/issues/506
+    with uproot3.recreate(output_file_name, compression=None) as root_file:
+        for (tree_name, tree), merging_algo in zip(trees.items(), merging_algos):
+
+            # Making branches to write to tree
+            branches, branches_init = uproot3utl.make_branches(tree, debug)
+
+            if debug:
+                print("\n%s branches keys:" %tree_name)
+                print(branches.keys())
+                print("\n%s branches_init keys:" %tree_name)
+                print(branches_init.keys())
+
+            # Save branches to ROOT file
+            uproot3utl.write_tree_to_root_file(root_file, tree_name, branches, branches_init)
+            print("\nTTree %s saved to output file %s" %(tree_name, output_file_name))
+
+    return
+
+
+def main(input_files, tree_names, merging_algos, output_file, debug):
+
+    print("Input files:")
+    print(input_files)
+
+    trees = {}
+    for tree_name, merging_algo in zip(tree_names, merging_algos):
+
+        if merging_algo == "branches":
+            branches_to_read = make_branches_to_read(input_files, tree_name)
+            branches = {}
+            for ifile, file_name in enumerate(input_files):
+                tree = uproot.open(file_name + ":" + tree_name)
+                for branch_name in branches_to_read[file_name]:
+                    branches[branch_name] = tree[branch_name].array()
+
+            trees[tree_name] = { k: v for k, v in branches.items() }
+
+        elif merging_algo == "events":
+            branches_to_read = get_all_branches_name(input_files[0], tree_name)
+            #branches_to_read = get_all_branches_name(input_files[0], tree_name)[-1100:-1000]
+            #branches_to_read = ["nJet"]
+            branches = {}
+            for ifile, file_name in enumerate(input_files):
+                tree = uproot.open(file_name + ":" + tree_name)
+                for branch_name in branches_to_read:
+                    if ifile == 0:
+                        branches[branch_name] = [tree[branch_name].array()]
+                    else:
+                        branches[branch_name].append(tree[branch_name].array())
+ 
+            trees[tree_name] = { k: ak.concatenate(v, axis=0) for k, v in branches.items() }
+
+        elif merging_algo.startswith("efficiencies"):
+            branches_to_read = get_all_branches_name(input_files[0], tree_name)
+            weight_branch_name = merging_algo.replace("efficiencies:", "")
+
+            branches = {}
+            weight_branches = {}
+
+            for ifile, file_name in enumerate(input_files):
+                tree = uproot.open(file_name + ":" + tree_name)
+                if ifile == 0:
+                    weight_branches = [ak.sum(uproot.open(file_name + ":" + weight_branch_name).array(), axis=0)]
+                else:
+                    weight_branches.append(ak.sum(uproot.open(file_name + ":" + weight_branch_name).array(), axis=0))
+
+                for branch_name in branches_to_read:
+                    if ifile == 0:
+                        branches[branch_name] = [tree[branch_name].array()]
+                    else:
+                        branches[branch_name].append(tree[branch_name].array())
+
+            trees[tree_name] = { k: sum([w*b for w, b in zip(weight_branches, v)])/sum(weight_branches) for k, v in branches.items() }
+            
+        elif merging_algo == "firstFound":
+            for ifile, file_name in enumerate(input_files):
+                file_ = uproot.open(file_name)
+                print(file_.keys())
+                if tree_name+";1" in file_.keys():
+                    print(file_[tree_name])
+                    tree = file_[tree_name].arrays()
+                    trees[tree_name] = { k: tree[k] for k in tree.fields }
+                    break
+
+        else:
+            print("ERROR: Unknown merging algorithm: %s" %merging_algo)
+            sys.exit()
+
+    ## Making output ROOT file
+    write_root_file(trees, merging_algos, output_file, debug)
+
+
+
+if __name__ == "__main__":
+
+    tstart = time.time()
+
+    ## Parse arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-i", "--inputfiles",
+        help="Input ROOT file used to make new branches",
+        required=True,
+        )
+    parser.add_argument(
+        "-t", "--trees",
+        help="Trees to merge",
+        required=True,
+        )
+    parser.add_argument(
+        "-m", "--mergingAlgo",
+        help="Merging algorithm. Choices=['branches', 'events', 'efficiencies:<treeName/genWeightBranchName>', 'firstFound']",
+        required=True,
+        )
+    parser.add_argument(
+        "-o", "--outputfile",
+        help="Output ROOT file name",
+        required=True,
+        )
+    parser.add_argument(
+        "-debug", "--debug",
+        help="Debug mode",
+        action="store_true",
+        )
+    
+    
+    args = parser.parse_args()
+
+    main(make_files_list(args.inputfiles), args.trees.split(","), args.mergingAlgo.split(","), args.outputfile, args.debug)
+
+
+    elapsed = time.time() - tstart
+    print("\nTotal elapsed time: %d s" %elapsed)
+
+

--- a/nTuplesMerger/mergeNTuples.py
+++ b/nTuplesMerger/mergeNTuples.py
@@ -47,7 +47,7 @@ def get_all_branch_names(file_name, tree_name):
     return uproot.open(file_name)[tree_name].keys()
 
 
-def make_branch_names_to_read_per_file(file_names, tree_name):
+def get_unique_branch_names(file_names, tree_name):
     """Return branches names to read in a tree for each file for branches merging algo.
 
     For 2 input files file1.root and file2.root with branches nJet, Jet_pt and
@@ -84,7 +84,7 @@ def branches_merging(file_names, tree_name):
            Keys are branch names, values are branch arrays
     """
 
-    branches_to_read = make_branch_names_to_read_per_file(file_names, tree_name)
+    branches_to_read = get_unique_branch_names(file_names, tree_name)
     branches = {}
     for file_name in file_names:
         tree = uproot.open(file_name + ":" + tree_name)

--- a/utilities/awkwardArrayUtilities.py
+++ b/utilities/awkwardArrayUtilities.py
@@ -112,3 +112,26 @@ def swap_axes(ak_array):
 
 def ak_to_ptyphim_four_vectors(ak_array, jet_idx):
     return np.array([ [ [c.pt, c.rapidity, c.phi, c.mass] for c in ak_array[ievent][ak_array[ievent].jetIdx == jet_idx] ] if ak.count(ak_array[ievent][ak_array[ievent].jetIdx == jet_idx], axis=None)>0 else [[1,1,1,1]] for ievent in range(ak.num(ak_array, axis=0)) ], dtype=object)
+
+
+def obj_to_ak_array(obj):
+    """Convert any input type to an awkward array.
+
+    Args:
+        obj (any type convertible to ak array)
+
+    Returns:
+        awkward.highlevel.Array
+    """
+
+    if isinstance(obj, ak.highlevel.Array):
+        ak_array = obj
+    elif isinstance(obj, np.ndarray):
+        ak_array = ak.Array(obj)
+    elif isinstance(obj, np.float32) or isinstance(obj, np.float64) or isinstance(obj, np.int32) or isinstance(obj, np.int64) \
+        or isinstance(obj, float) or isinstance(obj, int):
+        ak_array = ak.Array([obj])
+    else:
+        print("Unknown type %s" %(type(obj)))
+
+    return ak_array

--- a/utilities/uproot3Utilities.py
+++ b/utilities/uproot3Utilities.py
@@ -6,130 +6,8 @@ import re
 import sys
 
 import utilities
+import awkwardArrayUtilities as akutl
 
-
-def get_type(obj):
-    return str(type(obj)).split("'")[1]
-
-
-def send_casting_warning(dtype, new_dtype, branch_name):
-    print("WARNING: Casting branch %s from %s to %s because uproot does not handle %s!" %(branch_name, dtype, new_dtype, dtype))
-
-
-def send_max_value_warning(max_value_allowed, branch_name):
-    print("WARNING: Values in branch %s should NOT exceed %d." %(branch_name, max_value_allowed))
-
-
-def get_dtype(branch, branch_name="\b"):
-
-    if isinstance(branch, coffea.processor.accumulator.column_accumulator) \
-    or isinstance(branch, np.ndarray):
-        dtype = branch.dtype
-
-    elif isinstance(branch, ak.highlevel.Array):
-        dtype = ("%s" %ak.type(branch)).split("*")[-1][1:]
-
-    else:
-        supported_classes = ["coffea.processor.accumulator.column_accumulator", "numpy.ndarray", "awkward.highlevel.Array"]
-        print("ERROR: Branch %s is from an unsupported class: %s" %(branch_name, type(branch)))
-        print("Supported classes:")
-        for class_ in supported_classes: print("\t%s" %class_)
-        sys.exit()
-
-    # uint type is not supported by uproot3
-    # As long as values in the array do not exceed 2147483647 then casting brutaly from uint32 to int32 should be harmless
-    re_search = re.search(r'uint([0-9]+)', dtype)
-    if re_search:
-        nbits = int(re_search.group(1))
-        # int8 cannot be read properly by ROOT yet
-        if nbits == 8:
-            new_dtype = "int16"
-            print_max_value_warning = False
-        # int32, int64, ... are fine
-        else:
-            new_dtype = dtype[1:]
-            print_max_value_warning = True
-
-        send_casting_warning(dtype, new_dtype, branch_name)
-        if print_max_value_warning:
-            max_value_allowed = 2**(nbits-1) - 1
-            send_max_value_warning(max_value_allowed, branch_name)
-        dtype = new_dtype
-
-    #elif dtype == "bool":
-    #    new_dtype = "int32"
-    #    send_casting_warning(dtype, new_dtype, branch_name)
-    #    dtype = new_dtype
-        
-    return dtype
-
-
-def obj_to_ak_array(obj):
-    """Convert any input type to an awkward array.
-
-    Args:
-        obj (any type convertible to ak array)
-
-    Returns:
-        awkward.highlevel.Array
-    """
-
-    if isinstance(obj, ak.highlevel.Array):
-        ak_array = obj
-    elif isinstance(obj, np.ndarray):
-        ak_array = ak.Array(obj)
-    elif isinstance(obj, np.float32) or isinstance(obj, np.float64) or isinstance(obj, np.int32) or isinstance(obj, np.int64) \
-        or isinstance(obj, float) or isinstance(obj, int):
-        ak_array = ak.Array([obj])
-    else:
-        print("Unknown type %s" %(type(obj)))
-
-    return ak_array
-
-
-def get_size_branch_names(tree):
-    """Find the names of branches storing the size of jagged array branches.
-
-    By convention they are called n<CollectionName>.
-    E.g. nJet is the name of the size branch for Jet_pt.
-
-    Args:
-        tree (dict or coffea.processor.dict_accumulator)
-            Keys are the names of the branches in the tree
-
-    Returns:
-        list[str]
-    """
-
-    size_branch_names = []
-    for branch_name, branch in tree.items():
-        nbranch_name = "n"+str(branch_name.split("_")[0])
-        if (not branch_name.startswith("n")) and (nbranch_name in tree.keys()) and (nbranch_name not in size_branch_names):
-            size_branch_names.append(nbranch_name)
-
-    return size_branch_names
-
-
-def run_branch_checks(branches, branches_init, branches_size):
-    """Run some checks on the branches and remove branches failing checks.
-
-    """
-
-    def delete_branch(branch_name, branches, branches_init):
-        branches.pop(branch_name)
-        if branch_name in branches_init.keys():
-            branches_init.pop(branch_name)
-
-    size = utilities.most_common(branches_size.values())
-
-    branches_to_delete = [ branch_name for branch_name, branch_size in branches_size.items() if branch_size != size ]
-    for branch_name in branches_to_delete:
-        print("\nWARNING: Branch %s has size %d while most branches have size %d." %(branch_name, branches_size[branch_name], size))
-        print("         Deleting this branch!")
-        delete_branch(branch_name, branches, branches_init)
-
-    return
- 
 
 def make_branches(tree, debug=False):
     """Make branches and branches initailiazer to write a tree to a ROOT file.
@@ -142,46 +20,124 @@ def make_branches(tree, debug=False):
         tuple: (dict[awkward0.array.jagged.JaggedArray], dict[uproot3.write.objects.TTree.newbranch])
     """
 
-    ## Running sanity checks
-    tree_type = get_type(tree)
-    allowed_tree_types = ["dict", "coffea.processor.accumulator.dict_accumulator"]
-    if tree_type not in allowed_tree_types:
-        print("ERROR: Unknown tree type: %s" %tree_type)
-        print("       Allowed tree types:")
-        for type_ in allowed_tree_types: print("\t%s" %type_)
-        return None, None
+    def send_casting_warning(dtype, new_dtype, branch_name):
+        print("WARNING: Casting branch %s from %s to %s because uproot does not handle %s!" %(branch_name, dtype, new_dtype, dtype))
+        return
 
-    ## Book dict to return
-    branches = {}
-    branches_init = {}
-    branches_size = {}
 
-    ## Find names of the branches storing the size of jagged array branches
-    size_branch_names = get_size_branch_names(tree)
-    if debug:
-        print("\nSize branch names:")
-        print(size_branch_names)
+    def send_max_value_warning(max_value_allowed, branch_name):
+        print("WARNING: Values in branch %s should NOT exceed %d." %(branch_name, max_value_allowed))
+        return
 
-    ## Make branches and branches_init
-    #  Need to use ak0 and uproot3 because writing tree to ROOT file is not yet implemented in uproot4 (Feb. 2021)
-    if debug:
-        print("\nFilling branches and branches_init:")
 
-    for branch_name, branch in tree.items():
+    def get_dtype(branch, branch_name="\b"):
+        """Return branch data type.
 
-        if tree_type == "coffea.processor.accumulator.dict_accumulator":
+        Args:
+            branch (coffea.processor.accumulator.column_accumulator, branch, np.ndarray or
+                    awkward.highlevel.Array)
+            branch_name (str, optional): banch name for printing out precise warnings
+
+        Returns:
+            str
+        """
+
+        if isinstance(branch, coffea.processor.accumulator.column_accumulator) \
+        or isinstance(branch, np.ndarray):
+            dtype = branch.dtype
+
+        elif isinstance(branch, ak.highlevel.Array):
+            dtype = ("%s" %ak.type(branch)).split("*")[-1][1:]
+
+        else:
+            supported_classes = ["coffea.processor.accumulator.column_accumulator", "numpy.ndarray", "awkward.highlevel.Array"]
+            print("ERROR: Branch %s is from an unsupported class: %s" %(branch_name, type(branch)))
+            print("Supported classes:")
+            for class_ in supported_classes: print("\t%s" %class_)
+            sys.exit()
+
+        # uint type is not supported by uproot3
+        # As long as values in the array do not exceed 2147483647 then casting brutaly from uint32 to int32 should be harmless
+        re_search = re.search(r'uint([0-9]+)', dtype)
+        if re_search:
+            nbits = int(re_search.group(1))
+            # int8 cannot be read properly by ROOT yet
+            if nbits == 8:
+                new_dtype = "int16"
+                print_max_value_warning = False
+            # int32, int64, ... are fine
+            else:
+                new_dtype = dtype[1:]
+                print_max_value_warning = True
+
+            send_casting_warning(dtype, new_dtype, branch_name)
+            if print_max_value_warning:
+                max_value_allowed = 2**(nbits-1) - 1
+                send_max_value_warning(max_value_allowed, branch_name)
+            dtype = new_dtype
+
+        return dtype
+
+
+    def get_size_branch_names(tree):
+        """Find the names of branches storing the size of jagged array branches.
+
+        By convention they are called n<CollectionName>.
+        E.g. nJet is the name of the size branch for Jet_pt.
+
+        Args:
+            tree (dict or coffea.processor.dict_accumulator)
+                Keys are the names of the branches in the tree
+
+        Returns:
+            list[str]
+        """
+
+        size_branch_names = []
+        for branch_name, branch in tree.items():
+            nbranch_name = "n"+str(branch_name.split("_")[0])
+            if (not branch_name.startswith("n")) and (nbranch_name in tree.keys()) and (nbranch_name not in size_branch_names):
+                size_branch_names.append(nbranch_name)
+
+        return size_branch_names
+
+
+    def make_branch(branch, branch_name=""):
+        """Make tree branch in appropriate format for writing with uproot3.
+
+        Args:
+            branch (coffea.processor.accumulator.column_accumulator,
+                    awkward.highlevel.Array, numpy.ndarray, numpy.float, numpy.int)
+            branch_name (str)
+
+        Returns:
+            tuple (awkward0.array.jagged.JaggedArray or numpy.ndarray, int, str, str):
+                branch content, number of events, data type, awkward type
+        """
+
+        if isinstance(branch, coffea.processor.accumulator.column_accumulator):
             branch = branch.value
-        branch = obj_to_ak_array(branch)
-        #dtype = get_dtype(branch, branch_name)
-        dtype = get_dtype(branch)
-        branches_size[branch_name] = ak.num(branch, axis=0)
-        if debug:
-            print("%s:\ttype=%s   dtype=%s" %(branch_name, ak.type(branch), dtype))
+        branch = akutl.obj_to_ak_array(branch)
+        type_ = str(ak.type(branch))
+        dtype = get_dtype(branch, branch_name)
+        size = ak.num(branch, axis=0)
+        branch = ak.to_awkward0(branch)
 
-        # Define branch
-        branches[branch_name] = ak.to_awkward0(branch)
+        return branch, size, dtype, type_
 
-        # Define branch init
+
+    def make_branch_init(branch_name, dtype, size_branch_names):
+        """Make tree branch initializer for uproot3.
+        
+        Args:
+            branch_name (str)
+            dtype (str)
+            size_branch_names (list[str])
+
+        Returns:
+            uproot3.write.objects.TTree.newbranch or None
+        """
+
         if not branch_name.startswith("n"):
             nbranch_name = "n"+str(branch_name.split("_")[0])
             if nbranch_name in size_branch_names:
@@ -189,13 +145,73 @@ def make_branches(tree, debug=False):
                     new_dtype = "int16"
                     send_casting_warning(dtype, new_dtype, branch_name)
                     dtype = new_dtype
-                branches_init[branch_name] = uproot3.newbranch(dtype, size=nbranch_name)
+                branch_init = uproot3.newbranch(dtype, size=nbranch_name)
             else:
-                branches_init[branch_name] = uproot3.newbranch(dtype)
+                branch_init = uproot3.newbranch(dtype)
         else:
             if branch_name not in size_branch_names:
-                branches_init[branch_name] = uproot3.newbranch(dtype)
+                branch_init = uproot3.newbranch(dtype)
+            else:
+                branch_init = None
 
+        return branch_init
+
+
+    def run_branch_checks(branches, branches_init, branches_size):
+        """Run some checks on the branches and remove branches failing checks.
+
+        Args:
+            branches (dict[awkward0.array.jagged.JaggedArray or numpy.ndarray])
+            branches_init (dict[uproot3.write.objects.TTree.newbranch])
+            branches_size (dict[int])
+
+        Returns:
+            None
+        """
+
+        def delete_branch(branch_name, branches, branches_init):
+            branches.pop(branch_name)
+            if branch_name in branches_init.keys():
+                branches_init.pop(branch_name)
+
+            return
+
+        size = utilities.most_common(branches_size.values())
+
+        branches_to_delete = [ branch_name for branch_name, branch_size in branches_size.items() if branch_size != size ]
+        for branch_name in branches_to_delete:
+            print("\nWARNING: Branch %s has size %d while most branches have size %d." %(branch_name, branches_size[branch_name], size))
+            print("         Deleting this branch!")
+            delete_branch(branch_name, branches, branches_init)
+
+        return
+     
+
+    # Book dict to return
+    branches = {}
+    branches_init = {}
+
+    # Book dictionary storing branch length for branch checks
+    branches_size = {}
+
+    # Find names of the branches storing the size of jagged array branches
+    size_branch_names = get_size_branch_names(tree)
+    if debug:
+        print("\nSize branch names:")
+        print(size_branch_names)
+
+    # Make branches and branches_init
+    # Need to use ak0 and uproot3 because writing tree to ROOT file is not yet implemented in uproot4 (Feb. 2021)
+    if debug:
+        print("\nFilling branches and branches_init:")
+    for branch_name, branch in tree.items():
+        branches[branch_name], branches_size[branch_name], dtype, type_ = make_branch(branch, branch_name)
+        branch_init = make_branch_init(branch_name, dtype, size_branch_names)
+        if branch_init is not None: branches_init[branch_name] = branch_init
+        if debug:
+            print("%s:\ttype=%s   dtype=%s" %(branch_name, ak.type(branch), dtype))
+
+    # Run checks: e.g. delete branches with bugs, like incorrrect length
     run_branch_checks(branches, branches_init, branches_size)
 
     return branches, branches_init
@@ -217,5 +233,4 @@ def write_tree_to_root_file(file_, tree_name, branches, branches_init):
     file_[tree_name].extend(branches)
 
     return
-
 

--- a/utilities/uproot3Utilities.py
+++ b/utilities/uproot3Utilities.py
@@ -1,9 +1,10 @@
-import coffea
-import numpy as np
-import awkward as ak
-import uproot3
 import re
 import sys
+
+import numpy as np
+import awkward as ak
+from coffea import processor
+import uproot3
 
 import utilities
 import awkwardArrayUtilities as akutl
@@ -13,11 +14,11 @@ def make_branches(tree, debug=False):
     """Make branches and branches initailiazer to write a tree to a ROOT file.
 
     Args:
-        tree (dict[awkward.Array] or coffea.processor.dict_accumulator)
+        tree (dict[str, awkward.Array] or coffea.processor.dict_accumulator)
         debug (bool)
 
     Returns:
-        tuple: (dict[awkward0.array.jagged.JaggedArray], dict[uproot3.write.objects.TTree.newbranch])
+        tuple (dict[str, awkward0.array.jagged.JaggedArray], dict[str, uproot3.write.objects.TTree.newbranch])
     """
 
     def send_casting_warning(dtype, new_dtype, branch_name):
@@ -42,7 +43,7 @@ def make_branches(tree, debug=False):
             str
         """
 
-        if isinstance(branch, coffea.processor.accumulator.column_accumulator) \
+        if isinstance(branch, processor.accumulator.column_accumulator) \
         or isinstance(branch, np.ndarray):
             dtype = branch.dtype
 
@@ -115,7 +116,7 @@ def make_branches(tree, debug=False):
                 branch content, number of events, data type, awkward type
         """
 
-        if isinstance(branch, coffea.processor.accumulator.column_accumulator):
+        if isinstance(branch, processor.accumulator.column_accumulator):
             branch = branch.value
         branch = akutl.obj_to_ak_array(branch)
         type_ = str(ak.type(branch))
@@ -161,9 +162,9 @@ def make_branches(tree, debug=False):
         """Run some checks on the branches and remove branches failing checks.
 
         Args:
-            branches (dict[awkward0.array.jagged.JaggedArray or numpy.ndarray])
-            branches_init (dict[uproot3.write.objects.TTree.newbranch])
-            branches_size (dict[int])
+            branches (dict[str, awkward0.array.jagged.JaggedArray or numpy.ndarray])
+            branches_init (dict[str, uproot3.write.objects.TTree.newbranch])
+            branches_size (dict[str, int])
 
         Returns:
             None

--- a/utilities/uproot3Utilities.py
+++ b/utilities/uproot3Utilities.py
@@ -10,6 +10,173 @@ import utilities
 import awkwardArrayUtilities as akutl
 
 
+def __send_casting_warning(dtype, new_dtype, branch_name):
+    print("WARNING: Casting branch %s from %s to %s because uproot does not handle %s!" %(branch_name, dtype, new_dtype, dtype))
+    return
+
+
+def __send_max_value_warning(max_value_allowed, branch_name):
+    print("WARNING: Values in branch %s should NOT exceed %d." %(branch_name, max_value_allowed))
+    return
+
+
+def __get_dtype(branch, branch_name="\b"):
+    """Return branch data type.
+
+    Args:
+        branch (coffea.processor.accumulator.column_accumulator, branch, np.ndarray or
+                awkward.highlevel.Array)
+        branch_name (str, optional): banch name for printing out precise warnings
+
+    Returns:
+        str
+    """
+
+    if isinstance(branch, processor.accumulator.column_accumulator) \
+    or isinstance(branch, np.ndarray):
+        dtype = branch.dtype
+
+    elif isinstance(branch, ak.highlevel.Array):
+        dtype = ("%s" %ak.type(branch)).split("*")[-1][1:]
+
+    else:
+        supported_classes = ["coffea.processor.accumulator.column_accumulator", "numpy.ndarray", "awkward.highlevel.Array"]
+        print("ERROR: Branch %s is from an unsupported class: %s" %(branch_name, type(branch)))
+        print("Supported classes:")
+        for class_ in supported_classes: print("\t%s" %class_)
+        sys.exit()
+
+    # uint type is not supported by uproot3
+    # As long as values in the array do not exceed 2147483647 then casting brutaly from uint32 to int32 should be harmless
+    re_search = re.search(r'uint([0-9]+)', dtype)
+    if re_search:
+        nbits = int(re_search.group(1))
+        # int8 cannot be read properly by ROOT yet
+        if nbits == 8:
+            new_dtype = "int16"
+            print_max_value_warning = False
+        # int32, int64, ... are fine
+        else:
+            new_dtype = dtype[1:]
+            print_max_value_warning = True
+
+        __send_casting_warning(dtype, new_dtype, branch_name)
+        if print_max_value_warning:
+            max_value_allowed = 2**(nbits-1) - 1
+            __send_max_value_warning(max_value_allowed, branch_name)
+        dtype = new_dtype
+
+    return dtype
+
+
+def __get_size_branch_names(tree):
+    """Find the names of branches storing the size of jagged array branches.
+
+    By convention they are called n<CollectionName>.
+    E.g. nJet is the name of the size branch for Jet_pt.
+
+    Args:
+        tree (dict or coffea.processor.dict_accumulator)
+            Keys are the names of the branches in the tree
+
+    Returns:
+        list[str]
+    """
+
+    size_branch_names = []
+    for branch_name, branch in tree.items():
+        nbranch_name = "n"+str(branch_name.split("_")[0])
+        if (not branch_name.startswith("n")) and (nbranch_name in tree.keys()) and (nbranch_name not in size_branch_names):
+            size_branch_names.append(nbranch_name)
+
+    return size_branch_names
+
+
+def __make_branch(branch, branch_name=""):
+    """Make tree branch in appropriate format for writing with uproot3.
+
+    Args:
+        branch (coffea.processor.accumulator.column_accumulator,
+                awkward.highlevel.Array, numpy.ndarray, numpy.float, numpy.int)
+        branch_name (str)
+
+    Returns:
+        tuple (awkward0.array.jagged.JaggedArray or numpy.ndarray, int, str, str):
+            branch content, number of events, data type, awkward type
+    """
+
+    if isinstance(branch, processor.accumulator.column_accumulator):
+        branch = branch.value
+    branch = akutl.obj_to_ak_array(branch)
+    type_ = str(ak.type(branch))
+    dtype = __get_dtype(branch, branch_name)
+    size = ak.num(branch, axis=0)
+    branch = ak.to_awkward0(branch)
+
+    return branch, size, dtype, type_
+
+
+def __make_branch_init(branch_name, dtype, size_branch_names):
+    """Make tree branch initializer for uproot3.
+    
+    Args:
+        branch_name (str)
+        dtype (str)
+        size_branch_names (list[str])
+
+    Returns:
+        uproot3.write.objects.TTree.newbranch or None
+    """
+
+    if not branch_name.startswith("n"):
+        nbranch_name = "n"+str(branch_name.split("_")[0])
+        if nbranch_name in size_branch_names:
+            if dtype == "bool":
+                new_dtype = "int16"
+                __send_casting_warning(dtype, new_dtype, branch_name)
+                dtype = new_dtype
+            branch_init = uproot3.newbranch(dtype, size=nbranch_name)
+        else:
+            branch_init = uproot3.newbranch(dtype)
+    else:
+        if branch_name not in size_branch_names:
+            branch_init = uproot3.newbranch(dtype)
+        else:
+            branch_init = None
+
+    return branch_init
+
+
+def __run_branch_checks(branches, branches_init, branches_size):
+    """Run some checks on the branches and remove branches failing checks.
+
+    Args:
+        branches (dict[str, awkward0.array.jagged.JaggedArray or numpy.ndarray])
+        branches_init (dict[str, uproot3.write.objects.TTree.newbranch])
+        branches_size (dict[str, int])
+
+    Returns:
+        None
+    """
+
+    def delete_branch(branch_name, branches, branches_init):
+        branches.pop(branch_name)
+        if branch_name in branches_init.keys():
+            branches_init.pop(branch_name)
+
+        return
+
+    size = utilities.most_common(branches_size.values())
+
+    branches_to_delete = [ branch_name for branch_name, branch_size in branches_size.items() if branch_size != size ]
+    for branch_name in branches_to_delete:
+        print("\nWARNING: Branch %s has size %d while most branches have size %d." %(branch_name, branches_size[branch_name], size))
+        print("         Deleting this branch!")
+        delete_branch(branch_name, branches, branches_init)
+
+    return
+
+
 def make_branches(tree, debug=False):
     """Make branches and branches initailiazer to write a tree to a ROOT file.
 
@@ -21,171 +188,6 @@ def make_branches(tree, debug=False):
         tuple (dict[str, awkward0.array.jagged.JaggedArray], dict[str, uproot3.write.objects.TTree.newbranch])
     """
 
-    def send_casting_warning(dtype, new_dtype, branch_name):
-        print("WARNING: Casting branch %s from %s to %s because uproot does not handle %s!" %(branch_name, dtype, new_dtype, dtype))
-        return
-
-
-    def send_max_value_warning(max_value_allowed, branch_name):
-        print("WARNING: Values in branch %s should NOT exceed %d." %(branch_name, max_value_allowed))
-        return
-
-
-    def get_dtype(branch, branch_name="\b"):
-        """Return branch data type.
-
-        Args:
-            branch (coffea.processor.accumulator.column_accumulator, branch, np.ndarray or
-                    awkward.highlevel.Array)
-            branch_name (str, optional): banch name for printing out precise warnings
-
-        Returns:
-            str
-        """
-
-        if isinstance(branch, processor.accumulator.column_accumulator) \
-        or isinstance(branch, np.ndarray):
-            dtype = branch.dtype
-
-        elif isinstance(branch, ak.highlevel.Array):
-            dtype = ("%s" %ak.type(branch)).split("*")[-1][1:]
-
-        else:
-            supported_classes = ["coffea.processor.accumulator.column_accumulator", "numpy.ndarray", "awkward.highlevel.Array"]
-            print("ERROR: Branch %s is from an unsupported class: %s" %(branch_name, type(branch)))
-            print("Supported classes:")
-            for class_ in supported_classes: print("\t%s" %class_)
-            sys.exit()
-
-        # uint type is not supported by uproot3
-        # As long as values in the array do not exceed 2147483647 then casting brutaly from uint32 to int32 should be harmless
-        re_search = re.search(r'uint([0-9]+)', dtype)
-        if re_search:
-            nbits = int(re_search.group(1))
-            # int8 cannot be read properly by ROOT yet
-            if nbits == 8:
-                new_dtype = "int16"
-                print_max_value_warning = False
-            # int32, int64, ... are fine
-            else:
-                new_dtype = dtype[1:]
-                print_max_value_warning = True
-
-            send_casting_warning(dtype, new_dtype, branch_name)
-            if print_max_value_warning:
-                max_value_allowed = 2**(nbits-1) - 1
-                send_max_value_warning(max_value_allowed, branch_name)
-            dtype = new_dtype
-
-        return dtype
-
-
-    def get_size_branch_names(tree):
-        """Find the names of branches storing the size of jagged array branches.
-
-        By convention they are called n<CollectionName>.
-        E.g. nJet is the name of the size branch for Jet_pt.
-
-        Args:
-            tree (dict or coffea.processor.dict_accumulator)
-                Keys are the names of the branches in the tree
-
-        Returns:
-            list[str]
-        """
-
-        size_branch_names = []
-        for branch_name, branch in tree.items():
-            nbranch_name = "n"+str(branch_name.split("_")[0])
-            if (not branch_name.startswith("n")) and (nbranch_name in tree.keys()) and (nbranch_name not in size_branch_names):
-                size_branch_names.append(nbranch_name)
-
-        return size_branch_names
-
-
-    def make_branch(branch, branch_name=""):
-        """Make tree branch in appropriate format for writing with uproot3.
-
-        Args:
-            branch (coffea.processor.accumulator.column_accumulator,
-                    awkward.highlevel.Array, numpy.ndarray, numpy.float, numpy.int)
-            branch_name (str)
-
-        Returns:
-            tuple (awkward0.array.jagged.JaggedArray or numpy.ndarray, int, str, str):
-                branch content, number of events, data type, awkward type
-        """
-
-        if isinstance(branch, processor.accumulator.column_accumulator):
-            branch = branch.value
-        branch = akutl.obj_to_ak_array(branch)
-        type_ = str(ak.type(branch))
-        dtype = get_dtype(branch, branch_name)
-        size = ak.num(branch, axis=0)
-        branch = ak.to_awkward0(branch)
-
-        return branch, size, dtype, type_
-
-
-    def make_branch_init(branch_name, dtype, size_branch_names):
-        """Make tree branch initializer for uproot3.
-        
-        Args:
-            branch_name (str)
-            dtype (str)
-            size_branch_names (list[str])
-
-        Returns:
-            uproot3.write.objects.TTree.newbranch or None
-        """
-
-        if not branch_name.startswith("n"):
-            nbranch_name = "n"+str(branch_name.split("_")[0])
-            if nbranch_name in size_branch_names:
-                if dtype == "bool":
-                    new_dtype = "int16"
-                    send_casting_warning(dtype, new_dtype, branch_name)
-                    dtype = new_dtype
-                branch_init = uproot3.newbranch(dtype, size=nbranch_name)
-            else:
-                branch_init = uproot3.newbranch(dtype)
-        else:
-            if branch_name not in size_branch_names:
-                branch_init = uproot3.newbranch(dtype)
-            else:
-                branch_init = None
-
-        return branch_init
-
-
-    def run_branch_checks(branches, branches_init, branches_size):
-        """Run some checks on the branches and remove branches failing checks.
-
-        Args:
-            branches (dict[str, awkward0.array.jagged.JaggedArray or numpy.ndarray])
-            branches_init (dict[str, uproot3.write.objects.TTree.newbranch])
-            branches_size (dict[str, int])
-
-        Returns:
-            None
-        """
-
-        def delete_branch(branch_name, branches, branches_init):
-            branches.pop(branch_name)
-            if branch_name in branches_init.keys():
-                branches_init.pop(branch_name)
-
-            return
-
-        size = utilities.most_common(branches_size.values())
-
-        branches_to_delete = [ branch_name for branch_name, branch_size in branches_size.items() if branch_size != size ]
-        for branch_name in branches_to_delete:
-            print("\nWARNING: Branch %s has size %d while most branches have size %d." %(branch_name, branches_size[branch_name], size))
-            print("         Deleting this branch!")
-            delete_branch(branch_name, branches, branches_init)
-
-        return
      
 
     # Book dict to return
@@ -196,7 +198,7 @@ def make_branches(tree, debug=False):
     branches_size = {}
 
     # Find names of the branches storing the size of jagged array branches
-    size_branch_names = get_size_branch_names(tree)
+    size_branch_names = __get_size_branch_names(tree)
     if debug:
         print("\nSize branch names:")
         print(size_branch_names)
@@ -206,14 +208,14 @@ def make_branches(tree, debug=False):
     if debug:
         print("\nFilling branches and branches_init:")
     for branch_name, branch in tree.items():
-        branches[branch_name], branches_size[branch_name], dtype, type_ = make_branch(branch, branch_name)
-        branch_init = make_branch_init(branch_name, dtype, size_branch_names)
+        branches[branch_name], branches_size[branch_name], dtype, type_ = __make_branch(branch, branch_name)
+        branch_init = __make_branch_init(branch_name, dtype, size_branch_names)
         if branch_init is not None: branches_init[branch_name] = branch_init
         if debug:
             print("%s:\ttype=%s   dtype=%s" %(branch_name, ak.type(branch), dtype))
 
     # Run checks: e.g. delete branches with bugs, like incorrrect length
-    run_branch_checks(branches, branches_init, branches_size)
+    __run_branch_checks(branches, branches_init, branches_size)
 
     return branches, branches_init
 

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -1,3 +1,4 @@
+from collections import Counter
 import re
 import json
 
@@ -15,6 +16,11 @@ def list2str(L, strForConcatenation=""):
         s = L[0]
         for el in L[1:]: s = s + strForConcatenation + str(el)
         return(s)
+
+def most_common(list_):
+
+    data = Counter(list_)
+    return data.most_common(1)[0][0]
 
 
 def inregex(name, regexList):

--- a/utilities/utilities.py
+++ b/utilities/utilities.py
@@ -3,45 +3,67 @@ import re
 import json
 
 
-def list2str(L, strForConcatenation=""):
-    """
-    Takes a list of elements convertible to str and optionally a string.
-    Returns the concatenation of elements in the list separated by the optional string.
+def list2str(list_, str_for_concatenation=""):
+    """Concatenate elements of a list into an str.
+
+    Args:
+        list_ (list): List of elements convertible to str
+        str_for_concatenation (str, optional, default=""): Text to be placed
+            in between concatenated elements
+
+    Returns: 
+        str
 
     """
 
-    if len(L)==0:
-        return("")
+    if len(list_)==0:
+        text = ""
     else:
-        s = L[0]
-        for el in L[1:]: s = s + strForConcatenation + str(el)
-        return(s)
+        text = list_[0]
+        for el in list_[1:]: text = text + str_for_concatenation + str(el)
+
+    return text
+
 
 def most_common(list_):
+    """Returns most common element of a list.
+
+    Args:
+        list_ (list[T])
+
+    Returns:
+        T
+    """
 
     data = Counter(list_)
     return data.most_common(1)[0][0]
 
 
-def inregex(name, regexList):
+def inregex(name, regex_list):
     """
-    Takes a string text and either a regex or a list regexes.
     Returns the list of the indices of the regexes which the text matches.
     An empty list is returned if the text matches none of the regexes.
+
+    Args:
+        name (str)
+        regex_list (str or list)
     
+    Returns:
+        list[int]
     """
 
-    if type(regexList) != list:
-        regexList = [regexList]
+    if not isinstance(regex_list, list):
+        regex_list = [regex_list]
     indices = []
-    for idx, regex in enumerate(regexList):
+    for idx, regex in enumerate(regex_list):
         research = re.search(regex, name)
         if (research != None):
            indices.append(idx)
-    return(indices)
+
+    return indices
 
 
-def makeJsonData(jsonFileName):
+def make_json_data(json_file_name):
     """
     Take as input the name of a json file and return json data as a dictionary
     where constants from the "CONSTANTS" key are replaced by their corresponding
@@ -49,67 +71,67 @@ def makeJsonData(jsonFileName):
 
     """
 
-    with open(jsonFileName, 'r') as f:
-        jsonData = json.load(f)
-    return(makeDict(jsonData))
+    with open(json_file_name, 'r') as f:
+        json_data = json.load(f)
+    return make_dict(json_data)
 
 
-def makeDict(jsonDataIn, inplace=True):
+def make_dict(json_data_in, inplace=True):
     """
-    Take as input a dictionary representing json data, e.g. from json.load(filename)
-    with a key "CONSTANTS" defining constants to be replaced in the json file.
-    The key "CONSTANTS" will be removed from the dictionary.
-    Constants must be written as {constantName} in the rest of the json file.
-    The original dictionary is changed inplace by default. The original dictionary
-    given as inputA modified copy of the is untouched if setting inplace=False.
-    Return the modified dictionary in both cases (both inplace=True or False).
+    Args:
+        json_data_in (dict): Dictionary representing json data, e.g. from
+            json.load(file_name), with a key "CONSTANTS" defining constants
+            to be replaced in the json file.
+            The key "CONSTANTS" will be removed from the dictionary.
+            Constants must be written as {constant_name} in the rest of the json file.
+        inplace (bool, optional, default=True): Modify json data inplace (True)
+             or modify only a copy of the input dictionary (False)
 
-    Example:
-	{"CONSTANTS": {
-	    "PATH": "/eos/cms/store/group/phys_exotica/svjets/t_channel"
-	    },
-	 "files": ["{PATH}/1.root",
-                   "{PATH}/2.root"]
-        }
-    will be changed into:
-	{"files": ["/eos/cms/store/group/phys_exotica/svjets/t_channel/1.root",
-                   "/eos/cms/store/group/phys_exotica/svjets/t_channel/2.root"]
-        }
+    Returns:
+        dict: modified copy of the input dictionary
 
+    Examples:
+        >>> json_data_in = {
+                CONSTANTS": {"PATH": "/eos/cms/store/group/phys_exotica/svjets/t_channel"},
+	        "files": ["{PATH}/1.root", "{PATH}/2.root"]
+            }
+        >>> make_dict(json_data_in)
+        {'files': ['/eos/cms/store/group/phys_exotica/svjets/t_channel/1.root',
+                   '/eos/cms/store/group/phys_exotica/svjets/t_channel/2.root']}
     """
 
-    if "CONSTANTS" not in jsonDataIn.keys():
+    if "CONSTANTS" not in json_data_in.keys():
         print("WARNING: Cannot replace constants in json data because json data has no key \"CONSTANTS\".")
         print("         Returning json data as is.")
-        return(jsonDataIn)
+        return(json_data_in)
 
     if not inplace:
-        jsonData = jsonDataIn.copy()
+        json_data = json_data_in.copy()
     else:
-        jsonData = jsonDataIn
+        json_data = json_data_in
 
-    constants = jsonData["CONSTANTS"]
-    jsonData.pop("CONSTANTS", None)
+    constants = json_data["CONSTANTS"]
+    json_data.pop("CONSTANTS", None)
 
     regexes = [ (re.compile(r"\{"+const+"\}"), constants[const]) for const in constants.keys() ]
 
-    def replace(jsonData):
-        if isinstance(jsonData, dict):
-            for k, v in jsonData.items():
-                jsonData[k] = replace(v)
-            return(jsonData)
-        elif isinstance(jsonData, list):
-            for idx, v in enumerate(jsonData):
-                jsonData[idx] = replace(v)
-            return(jsonData)
-        elif isinstance(jsonData, str):
+    def replace(json_data):
+        if isinstance(json_data, dict):
+            for k, v in json_data.items():
+                json_data[k] = replace(v)
+            return json_data
+        elif isinstance(json_data, list):
+            for idx, v in enumerate(json_data):
+                json_data[idx] = replace(v)
+            return json_data
+        elif isinstance(json_data, str):
             for regex, repl in regexes:
-                jsonData = re.sub(regex, repl, jsonData)
-            return(jsonData)
+                json_data = re.sub(regex, repl, json_data)
+            return json_data
         else:
-            return(jsonData)
+            return json_data
 
-    replace(jsonData)
-    return(jsonData)
+    replace(json_data)
+    return json_data
      
 


### PR DESCRIPTION
Improve `utilities/uproot3Utilities.py`, in particular some code simplification and handling the fact that `uint8`, `uint32`, `uint64`, `int8`, `bool` types are not supported by uproot3 for rectangular and/or jagged arrays.

Remove branches with the a different length than the majority of the branches. This happen for a small number of files in PFNanoAOD 106X_v02, bug in PFNanoAOD code?

Add ROOT NTuples merger code in `nTuplesMerger/` to add together files with:
  * trees with different branches storing same events
  * trees with same branches storing different events
  * trees with branches representing cuts efficiencies
  * first found tree (in case adding together two files with a same tree, i.e. same events and same branches)